### PR TITLE
Use Set instead of when collecting project dependencies

### DIFF
--- a/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/AlignmentService.java
+++ b/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/AlignmentService.java
@@ -1,6 +1,6 @@
 package org.jboss.gm.analyzer.alignment;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 
@@ -9,15 +9,15 @@ public interface AlignmentService {
     Response align(Request request);
 
     class Request {
-        private final List<? extends ProjectVersionRef> dependencies;
+        private final Collection<? extends ProjectVersionRef> dependencies;
         private final ProjectVersionRef project;
 
-        public Request(ProjectVersionRef project, List<? extends ProjectVersionRef> dependencies) {
+        public Request(ProjectVersionRef project, Collection<? extends ProjectVersionRef> dependencies) {
             this.dependencies = dependencies;
             this.project = project;
         }
 
-        List<? extends ProjectVersionRef> getDependencies() {
+        Collection<? extends ProjectVersionRef> getDependencies() {
             return dependencies;
         }
 

--- a/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/AlignmentTask.java
+++ b/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/AlignmentTask.java
@@ -4,7 +4,10 @@ import static org.jboss.gm.analyzer.alignment.AlignmentUtils.getCurrentAlignment
 import static org.jboss.gm.analyzer.alignment.AlignmentUtils.writeUpdatedAlignmentModel;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 import org.gradle.api.DefaultTask;
@@ -27,7 +30,7 @@ public class AlignmentTask extends DefaultTask {
         final String projectName = project.getName();
         System.out.println("Starting alignment task for project " + projectName);
 
-        final List<ProjectVersionRef> deps = getAllProjectDependencies(project);
+        final Collection<ProjectVersionRef> deps = getAllProjectDependencies(project);
         final AlignmentService alignmentService = AlignmentServiceFactory.getAlignmentService(project);
         final AlignmentService.Response alignmentResponse = alignmentService.align(
                 new AlignmentService.Request(
@@ -42,15 +45,15 @@ public class AlignmentTask extends DefaultTask {
         writeUpdatedAlignmentModel(project, alignmentModel);
     }
 
-    private List<ProjectVersionRef> getAllProjectDependencies(Project project) {
-        final List<ProjectVersionRef> result = new ArrayList<>();
+    private Collection<ProjectVersionRef> getAllProjectDependencies(Project project) {
+        final Set<ProjectVersionRef> result = new LinkedHashSet<>();
         project.getConfigurations().all(configuration -> configuration.getAllDependencies().forEach(d -> result.add(
                 AlignmentUtils.withGAVAndConfiguration(d.getGroup(), d.getName(), d.getVersion(), configuration.getName()))));
         return result;
     }
 
     private void updateModuleDependencies(AlignmentModel.Module correspondingModule,
-            List<ProjectVersionRef> allModuleDependencies, AlignmentService.Response alignmentResponse) {
+            Collection<ProjectVersionRef> allModuleDependencies, AlignmentService.Response alignmentResponse) {
 
         final List<ProjectVersionRef> alignedDependencies = new ArrayList<>();
         allModuleDependencies.forEach(d -> {

--- a/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/DummyAlignmentService.java
+++ b/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/DummyAlignmentService.java
@@ -24,7 +24,7 @@ public class DummyAlignmentService implements AlignmentService {
             return result;
         }
 
-        final ProjectVersionRef first = request.getDependencies().get(0);
+        final ProjectVersionRef first = request.getDependencies().iterator().next();
         result.put(first.toString(), first.getVersionString() + "-redhat-00001");
         return result;
     }


### PR DESCRIPTION
This is done to avoid having duplicates due to the multitude of Gradle
configurations