### PR TITLE
Only apply publishing actions when corresponding plugins exist

### DIFF
--- a/manipulation/src/functTest/resources/multi-module/build.gradle
+++ b/manipulation/src/functTest/resources/multi-module/build.gradle
@@ -7,6 +7,7 @@ allprojects {
     group = 'org.acme'
 
     apply plugin: 'java'
+    apply plugin: 'maven-publish'
     apply plugin: 'org.jboss.gm.manipulation'
 
     repositories {

--- a/manipulation/src/functTest/resources/simple-project/build.gradle
+++ b/manipulation/src/functTest/resources/simple-project/build.gradle
@@ -2,6 +2,7 @@ plugins {
     // including this plugin directly instead of by an init script, which allows to use the freshly build version
     id 'org.jboss.gm.manipulation'
     id 'java'
+    id 'maven-publish'
 }
 
 sourceCompatibility = 1.8

--- a/manipulation/src/main/java/org/jboss/gm/manipulation/ManipulationPlugin.java
+++ b/manipulation/src/main/java/org/jboss/gm/manipulation/ManipulationPlugin.java
@@ -17,9 +17,6 @@ public class ManipulationPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        // apply the maven publishing plugin
-        project.getPluginManager().apply(MavenPublishPlugin.class);
-
         // get the previously performed alignment
         final ManipulationModel alignmentModel = getCurrentAlignmentModel(project.getRootDir());
         final ManipulationModel correspondingModule = alignmentModel.findCorrespondingChild(project.getName());

--- a/manipulation/src/main/java/org/jboss/gm/manipulation/actions/PublicationPomTransformerAction.java
+++ b/manipulation/src/main/java/org/jboss/gm/manipulation/actions/PublicationPomTransformerAction.java
@@ -23,6 +23,10 @@ public class PublicationPomTransformerAction implements Action<Project> {
 
     @Override
     public void execute(Project project) {
+        if (!project.getPluginManager().hasPlugin("maven-publish")) {
+            return;
+        }
+
         project.getPlugins().withType(MavenPublishPlugin.class,
                 plugin -> project.getExtensions().configure(PublishingExtension.class, extension -> {
                     extension.getPublications().withType(MavenPublication.class).all(maven -> {

--- a/manipulation/src/main/java/org/jboss/gm/manipulation/actions/PublishingRepositoryAction.java
+++ b/manipulation/src/main/java/org/jboss/gm/manipulation/actions/PublishingRepositoryAction.java
@@ -46,6 +46,10 @@ public class PublishingRepositoryAction implements Action<Project> {
 
     @Override
     public void execute(Project project) {
+        if (!project.getPluginManager().hasPlugin("maven-publish")) {
+            return;
+        }
+
         String pncDeployUrl = System.getProperty(URL_SYSTEM_PROPERTY);
         if (pncDeployUrl != null) {
             project.getPlugins().withType(MavenPublishPlugin.class, plugin -> {

--- a/manipulation/src/main/java/org/jboss/gm/manipulation/actions/UploadTaskTransformerAction.java
+++ b/manipulation/src/main/java/org/jboss/gm/manipulation/actions/UploadTaskTransformerAction.java
@@ -21,6 +21,10 @@ public class UploadTaskTransformerAction implements Action<Project> {
 
     @Override
     public void execute(Project project) {
+        if (!project.getPluginManager().hasPlugin("maven")) {
+            return;
+        }
+
         project.getTasks().withType(Upload.class).all(upload -> upload.getRepositories()
                 .withType(MavenResolver.class).all(resolver -> {
                     resolver.getPom().withXml(new PomTransformer(alignmentConfiguration));


### PR DESCRIPTION
This is needed because projects that have the "maven" plugin configured
can fail when the maven-publish tasks are applied