### PR TITLE
NCL-4658 Add init gradle file

### DIFF
--- a/init/src/analyzer.init.gradle
+++ b/init/src/analyzer.init.gradle
@@ -1,0 +1,33 @@
+
+
+initscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.jboss.gm.analyzer:analyzer:0.1-SNAPSHOT'
+        }
+}
+
+allprojects {
+
+    // Quieten down logging from other parts of Gradle/Tasks.
+    gradle.taskGraph.beforeTask { Task task ->
+        if ( "generateAlignmentMetadata" == task.name ) {
+            logger.context.level = LogLevel.INFO
+        }
+    }
+    gradle.taskGraph.afterTask { Task task ->
+        logger.context.level = LogLevel.QUIET
+    }
+    gradle.startParameter.logLevel = LogLevel.QUIET
+    logger.context.level = LogLevel.QUIET
+    
+    
+    
+    ext.gmeAnalyse = true
+
+    apply plugin: org.jboss.gm.analyzer.alignment.AlignmentPlugin
+    
+}


### PR DESCRIPTION
Directory structure can be discussed and whether to add my `init.iml` that I use for configuring this sub-module (it basically sets up groovy and adds gradle to the classpath).