### PR TITLE
NCL-4657 Make plugins work with Spring Dependency Management Plugin

### DIFF
--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleProjectWithSpringDMPluginFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleProjectWithSpringDMPluginFunctionalTest.java
@@ -1,0 +1,70 @@
+package org.jboss.gm.analyzer.alignment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collection;
+
+import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
+import org.gradle.api.Project;
+import org.jboss.gm.common.Configuration;
+import org.jboss.gm.common.alignment.ManipulationModel;
+import org.jboss.gm.common.alignment.Utils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
+
+public class SimpleProjectWithSpringDMPluginFunctionalTest extends AbstractWiremockTest {
+
+    @Rule
+    public final TestRule restoreSystemProperties = new RestoreSystemProperties();
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException, URISyntaxException {
+        stubFor(post(urlEqualTo("/da/rest/v-1/reports/lookup/gavs"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json;charset=utf-8")
+                        .withBody(readSampleDAResponse("simple-project-with-spring-dm-plugin-da-response.json"))));
+
+        System.setProperty(Configuration.DA, "http://127.0.0.1:" + AbstractWiremockTest.PORT + "/da/rest/v-1");
+    }
+
+    @Test
+    public void ensureAlignmentFileCreated() throws IOException, URISyntaxException {
+        final File projectRoot = tempDir.newFolder("simple-project-with-spring-dm-plugin");
+        final ManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
+
+        assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
+        assertEquals(AlignmentTask.LOAD_GME, Utils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
+
+        assertThat(alignmentModel).isNotNull().satisfies(am -> {
+            assertThat(am.getGroup()).isEqualTo("org.acme.gradle");
+            assertThat(am.getName()).isEqualTo("root");
+            assertThat(am.findCorrespondingChild("root")).satisfies(root -> {
+                assertThat(root.getVersion()).isEqualTo("1.0.1.redhat-00001");
+                assertThat(root.getName()).isEqualTo("root");
+                final Collection<ProjectVersionRef> alignedDependencies = root.getAlignedDependencies().values();
+                assertThat(alignedDependencies)
+                        .extracting("artifactId", "versionString")
+                        .containsOnly(
+                                tuple("infinispan-core", "8.2.11.Final-redhat-00004"));
+            });
+        });
+    }
+}

--- a/analyzer/src/functTest/resources/simple-project-with-spring-dm-plugin-da-response.json
+++ b/analyzer/src/functTest/resources/simple-project-with-spring-dm-plugin-da-response.json
@@ -1,0 +1,30 @@
+[
+  {
+    "bestMatchVersion": "8.2.11.Final-redhat-00004",
+    "availableVersions": [
+      "8.2.11.Final-redhat-00004",
+      "8.2.11.Final-redhat-00003",
+      "8.2.11.Final-redhat-00001"
+    ],
+    "blacklisted": false,
+    "whitelisted": [
+      {
+        "name": "EAP",
+        "version": "7.1.3",
+        "supportStatus": "SUPPORTED"
+      }
+    ],
+    "version": "8.2.11.Final",
+    "groupId": "org.infinispan",
+    "artifactId": "infinispan-core"
+  },
+  {
+    "bestMatchVersion": null,
+    "availableVersions": [],
+    "blacklisted": false,
+    "whitelisted": [],
+    "version": "1.0.0",
+    "groupId": "org.acme",
+    "artifactId": "root"
+  }
+]

--- a/analyzer/src/functTest/resources/simple-project-with-spring-dm-plugin/build.gradle
+++ b/analyzer/src/functTest/resources/simple-project-with-spring-dm-plugin/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    // including this plugin directly instead of by an init script, which allows to use the freshly build version
+    id 'org.jboss.gm.analyzer'
+    id 'java'
+    id "io.spring.dependency-management" version "1.0.6.RELEASE"
+}
+
+
+apply plugin: "io.spring.dependency-management"
+
+sourceCompatibility = 1.8
+
+
+repositories {
+    mavenCentral()
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.boot:spring-boot-dependencies:1.5.19.RELEASE"
+    }
+}
+
+dependencies {
+    // define dependencies without versions
+    implementation("org.infinispan:infinispan-core")
+    
+    // define dependency not in BOM
+    implementation("io.smallrye:smallrye-open-api:1.1.3")
+}

--- a/analyzer/src/functTest/resources/simple-project-with-spring-dm-plugin/gradle.properties
+++ b/analyzer/src/functTest/resources/simple-project-with-spring-dm-plugin/gradle.properties
@@ -1,0 +1,2 @@
+group=org.acme.gradle
+version=1.0.1

--- a/analyzer/src/functTest/resources/simple-project-with-spring-dm-plugin/settings.gradle
+++ b/analyzer/src/functTest/resources/simple-project-with-spring-dm-plugin/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'root'

--- a/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/AlignmentTask.java
+++ b/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/AlignmentTask.java
@@ -15,12 +15,16 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import org.apache.commons.lang.StringUtils;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 import org.commonjava.maven.ext.common.ManipulationException;
 import org.commonjava.maven.ext.common.ManipulationUncheckedException;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.result.DependencyResult;
+import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.internal.artifacts.dependencies.DefaultSelfResolvingDependency;
+import org.gradle.api.internal.artifacts.result.DefaultResolvedDependencyResult;
 import org.gradle.api.tasks.TaskAction;
 import org.jboss.gm.common.ProjectVersionFactory;
 import org.jboss.gm.common.alignment.ManipulationModel;
@@ -106,17 +110,55 @@ public class AlignmentTask extends DefaultTask {
 
     private Collection<ProjectVersionRef> getAllProjectDependencies(Project project) {
         final Set<ProjectVersionRef> result = new LinkedHashSet<>();
-        project.getConfigurations().all(configuration -> configuration.getAllDependencies().forEach(dep -> {
-            if (dep instanceof DefaultSelfResolvingDependency) {
-                logger.warn("Ignoring dependency of type {} on project {}", dep.getClass().getName(), project.getName());
-            } else if (isEmpty(dep.getVersion())) {
-                logger.warn("Ignoring empty version on dependency {} on project {}", dep.toString(), project.getName());
-            } else {
-                result.add(ProjectVersionFactory.withGAVAndConfiguration(dep.getGroup(), dep.getName(), dep.getVersion(),
-                        configuration.getName()));
-            }
-        }));
+        project.getConfigurations().all(configuration -> {
+            final ResolutionResult resolutionResult = configuration.getIncoming()
+                    .getResolutionResult();//force dependency resolution - this is needed later on if we encounter deps with no version
+            configuration.getAllDependencies().forEach(dep -> {
+                if (dep instanceof DefaultSelfResolvingDependency) {
+                    logger.warn("Ignoring dependency of type {} on project {}", dep.getClass().getName(), project.getName());
+                } else if (isEmpty(dep.getVersion())) {
+                    // look up resolved dependency with a toString hack
+                    boolean found = false;
+                    final Set<? extends DependencyResult> resolvedDependencies = getAllDependenciesFromResolutionResult(
+                            resolutionResult);
+                    for (DependencyResult resolvedDependency : resolvedDependencies) {
+                        if (!(resolvedDependency instanceof DefaultResolvedDependencyResult)) {
+                            continue;
+                        }
+
+                        final String resolvedDependencyDisplayName = ((DefaultResolvedDependencyResult) resolvedDependency)
+                                .getSelected()
+                                .getId().getDisplayName();
+                        // the display name should be something like: "org.example:somelib:1.2.3"
+                        if (resolvedDependencyDisplayName.startsWith(dep.getGroup() + ":" + dep.getName()) && StringUtils
+                                .countMatches(resolvedDependencyDisplayName, ":") == 2) {
+                            final int i = resolvedDependencyDisplayName.lastIndexOf(":");
+                            if (i != -1) {
+                                result.add(ProjectVersionFactory.withGAVAndConfiguration(dep.getGroup(), dep.getName(),
+                                        resolvedDependencyDisplayName.substring(i + 1),
+                                        configuration.getName()));
+                                found = true;
+                            }
+                        }
+                    }
+                    if (!found) {
+                        logger.warn("Ignoring empty version on dependency {} on project {}", dep.toString(), project.getName());
+                    }
+                } else {
+                    result.add(ProjectVersionFactory.withGAVAndConfiguration(dep.getGroup(), dep.getName(), dep.getVersion(),
+                            configuration.getName()));
+                }
+            });
+        });
         return result;
+    }
+
+    private Set<? extends DependencyResult> getAllDependenciesFromResolutionResult(ResolutionResult resolutionResult) {
+        try {
+            return resolutionResult.getAllDependencies();
+        } catch (Exception e) {
+            return new HashSet<>();
+        }
     }
 
     private void updateModuleDependencies(ManipulationModel correspondingModule,

--- a/manipulation/src/functTest/java/org/jboss/gm/manipulation/SimpleProjectWithMisconfiguredSpringDMAndMavenPluginsFunctionalTest.java
+++ b/manipulation/src/functTest/java/org/jboss/gm/manipulation/SimpleProjectWithMisconfiguredSpringDMAndMavenPluginsFunctionalTest.java
@@ -1,0 +1,42 @@
+package org.jboss.gm.manipulation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.UnexpectedBuildFailure;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SimpleProjectWithMisconfiguredSpringDMAndMavenPluginsFunctionalTest {
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Test
+    public void ensureProperPomGenerated() throws IOException, URISyntaxException {
+        // this makes gradle use the set property as maven local directory
+        // we do this in order to avoid polluting the maven local and also be absolutely sure
+        // that no prior invocations affect the execution
+        final File m2Directory = tempDir.newFolder(".m2");
+        System.setProperty("maven.repo.local", m2Directory.getAbsolutePath());
+
+        final File simpleProjectRoot = tempDir.newFolder("simple-project-with-misconfigured-spring-dm-and-maven-plugins");
+        TestUtils.copyDirectory("simple-project-with-misconfigured-spring-dm-and-maven-plugins", simpleProjectRoot);
+        assertThat(simpleProjectRoot.toPath().resolve("build.gradle")).exists();
+
+        assertThatExceptionOfType(UnexpectedBuildFailure.class).isThrownBy(() -> {
+            GradleRunner.create()
+                    .withProjectDir(simpleProjectRoot)
+                    .withArguments("install")
+                    .withDebug(true)
+                    .withPluginClasspath()
+                    .build();
+        }).withMessageContaining("cannot be used together");
+    }
+}

--- a/manipulation/src/functTest/java/org/jboss/gm/manipulation/SimpleProjectWithSpringDMAndMavenPluginsFunctionalTest.java
+++ b/manipulation/src/functTest/java/org/jboss/gm/manipulation/SimpleProjectWithSpringDMAndMavenPluginsFunctionalTest.java
@@ -1,0 +1,59 @@
+package org.jboss.gm.manipulation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.maven.model.Model;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.jboss.gm.common.alignment.ManipulationModel;
+import org.jboss.gm.common.alignment.ManipulationUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SimpleProjectWithSpringDMAndMavenPluginsFunctionalTest {
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Test
+    public void ensureProperPomGenerated() throws IOException, URISyntaxException, XmlPullParserException {
+        // this makes gradle use the set property as maven local directory
+        // we do this in order to avoid polluting the maven local and also be absolutely sure
+        // that no prior invocations affect the execution
+        final File m2Directory = tempDir.newFolder(".m2");
+        System.setProperty("maven.repo.local", m2Directory.getAbsolutePath());
+
+        final File simpleProjectRoot = tempDir.newFolder("simple-project-with-spring-dm-and-maven-plugins");
+        TestUtils.copyDirectory("simple-project-with-spring-dm-and-maven-plugins", simpleProjectRoot);
+        assertThat(simpleProjectRoot.toPath().resolve("build.gradle")).exists();
+
+        final ManipulationModel alignment = ManipulationUtils.getManipulationModelAt(simpleProjectRoot);
+
+        final BuildResult buildResult = GradleRunner.create()
+                .withProjectDir(simpleProjectRoot)
+                .withArguments("install")
+                .withDebug(true)
+                .withPluginClasspath()
+                .build();
+        assertThat(buildResult.task(":install").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+
+        final Pair<Model, ManipulationModel> modelAndModule = TestUtils.getModelAndCheckGAV(m2Directory, alignment,
+                "org/acme/root/1.0.1-redhat-00001/root-1.0.1-redhat-00001.pom", true);
+        final ManipulationModel module = modelAndModule.getRight();
+        assertThat(modelAndModule.getLeft().getDependencies())
+                .extracting("artifactId", "version")
+                .containsOnly(
+                        TestUtils.getAlignedTuple(module, "commons-lang3", "3.8.1"),
+                        TestUtils.getAlignedTuple(module, "hibernate-core"),
+                        TestUtils.getAlignedTuple(module, "undertow-core"),
+                        TestUtils.getAlignedTuple(module, "junit", "4.12"));
+    }
+}

--- a/manipulation/src/functTest/resources/simple-project-with-misconfigured-spring-dm-and-maven-plugins/build.gradle
+++ b/manipulation/src/functTest/resources/simple-project-with-misconfigured-spring-dm-and-maven-plugins/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    // including this plugin directly instead of by an init script, which allows to use the freshly build version
+    id 'org.jboss.gm.manipulation'
+    id 'java'
+    id 'maven'
+    id "io.spring.dependency-management" version "1.0.6.RELEASE"
+}
+
+sourceCompatibility = 1.8
+
+
+repositories {
+    mavenCentral()
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.boot:spring-boot-dependencies:1.5.19.RELEASE"
+    }
+}
+
+dependencies {
+    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.8.1'
+    compile group: 'org.hibernate', name: 'hibernate-core'
+    compile group: 'io.undertow', name: 'undertow-core', version: '1.4.26.Final'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+}

--- a/manipulation/src/functTest/resources/simple-project-with-misconfigured-spring-dm-and-maven-plugins/gradle.properties
+++ b/manipulation/src/functTest/resources/simple-project-with-misconfigured-spring-dm-and-maven-plugins/gradle.properties
@@ -1,0 +1,2 @@
+group=org.acme
+version=1.0.1

--- a/manipulation/src/functTest/resources/simple-project-with-misconfigured-spring-dm-and-maven-plugins/manipulation.json
+++ b/manipulation/src/functTest/resources/simple-project-with-misconfigured-spring-dm-and-maven-plugins/manipulation.json
@@ -1,0 +1,17 @@
+{
+  "group": "org.acme",
+  "name": "root",
+  "version": "1.0.1-redhat-00001",
+  "alignedDependencies": {
+    "org.hibernate:hibernate-core:5.0.12.Final": {
+      "groupId": "org.hibernate",
+      "artifactId": "hibernate-core",
+      "version": "5.0.11.Final"
+    },
+    "io.undertow:undertow-core:1.4.26.Final": {
+      "groupId": "io.undertow",
+      "artifactId": "undertow-core",
+      "version": "1.4.25.Final"
+    }
+  }
+}

--- a/manipulation/src/functTest/resources/simple-project-with-misconfigured-spring-dm-and-maven-plugins/settings.gradle
+++ b/manipulation/src/functTest/resources/simple-project-with-misconfigured-spring-dm-and-maven-plugins/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'root'

--- a/manipulation/src/functTest/resources/simple-project-with-misconfigured-spring-dm-and-maven-plugins/src/main/java/org/acme/root/Main.java
+++ b/manipulation/src/functTest/resources/simple-project-with-misconfigured-spring-dm-and-maven-plugins/src/main/java/org/acme/root/Main.java
@@ -1,0 +1,8 @@
+package org.acme.root;
+
+public class Main {
+	public static void main(String[]args) {
+
+	}
+}
+

--- a/manipulation/src/functTest/resources/simple-project-with-spring-dm-and-maven-plugins/build.gradle
+++ b/manipulation/src/functTest/resources/simple-project-with-spring-dm-and-maven-plugins/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    // including this plugin directly instead of by an init script, which allows to use the freshly build version
+    id 'org.jboss.gm.manipulation'
+    id 'java'
+    id 'maven'
+    id "io.spring.dependency-management" version "1.0.6.RELEASE"
+}
+
+sourceCompatibility = 1.8
+
+
+repositories {
+    mavenCentral()
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.boot:spring-boot-dependencies:1.5.19.RELEASE"
+    }
+    generatedPomCustomization {
+        enabled = false
+    }
+}
+
+dependencies {
+    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.8.1'
+    compile group: 'org.hibernate', name: 'hibernate-core'
+    compile group: 'io.undertow', name: 'undertow-core', version: '1.4.26.Final'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+}

--- a/manipulation/src/functTest/resources/simple-project-with-spring-dm-and-maven-plugins/gradle.properties
+++ b/manipulation/src/functTest/resources/simple-project-with-spring-dm-and-maven-plugins/gradle.properties
@@ -1,0 +1,2 @@
+group=org.acme
+version=1.0.1

--- a/manipulation/src/functTest/resources/simple-project-with-spring-dm-and-maven-plugins/manipulation.json
+++ b/manipulation/src/functTest/resources/simple-project-with-spring-dm-and-maven-plugins/manipulation.json
@@ -1,0 +1,17 @@
+{
+  "group": "org.acme",
+  "name": "root",
+  "version": "1.0.1-redhat-00001",
+  "alignedDependencies": {
+    "org.hibernate:hibernate-core:5.0.12.Final": {
+      "groupId": "org.hibernate",
+      "artifactId": "hibernate-core",
+      "version": "5.0.11.Final"
+    },
+    "io.undertow:undertow-core:1.4.26.Final": {
+      "groupId": "io.undertow",
+      "artifactId": "undertow-core",
+      "version": "1.4.25.Final"
+    }
+  }
+}

--- a/manipulation/src/functTest/resources/simple-project-with-spring-dm-and-maven-plugins/settings.gradle
+++ b/manipulation/src/functTest/resources/simple-project-with-spring-dm-and-maven-plugins/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'root'

--- a/manipulation/src/functTest/resources/simple-project-with-spring-dm-and-maven-plugins/src/main/java/org/acme/root/Main.java
+++ b/manipulation/src/functTest/resources/simple-project-with-spring-dm-and-maven-plugins/src/main/java/org/acme/root/Main.java
@@ -1,0 +1,8 @@
+package org.acme.root;
+
+public class Main {
+	public static void main(String[]args) {
+
+	}
+}
+

--- a/manipulation/src/main/java/org/jboss/gm/manipulation/actions/AlignedDependencyResolver.java
+++ b/manipulation/src/main/java/org/jboss/gm/manipulation/actions/AlignedDependencyResolver.java
@@ -6,6 +6,7 @@ import static org.jboss.gm.common.ProjectVersionFactory.withGAV;
 import java.util.Map;
 
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
+import org.commonjava.maven.atlas.ident.ref.SimpleProjectRef;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencyResolveDetails;
 import org.gradle.api.artifacts.ModuleVersionSelector;
@@ -18,23 +19,34 @@ import org.slf4j.LoggerFactory;
  */
 public class AlignedDependencyResolver implements Action<DependencyResolveDetails> {
     private final ManipulationModel module;
+    private final ResolvedDependenciesRepository resolvedDependenciesRepository;
 
     private static final Logger logger = LoggerFactory.getLogger(AlignedDependencyResolver.class);
 
-    public AlignedDependencyResolver(ManipulationModel module) {
+    public AlignedDependencyResolver(ManipulationModel module, ResolvedDependenciesRepository resolvedDependenciesRepository) {
         this.module = module;
+        this.resolvedDependenciesRepository = resolvedDependenciesRepository;
     }
 
     @Override
     public void execute(DependencyResolveDetails resolveDetails) {
         final ModuleVersionSelector requested = resolveDetails.getRequested();
+        String version = requested.getVersion();
         if (isEmpty(requested.getVersion())) {
-            // this is the case with managed dependencies, where version is provided at resolution time
-            logger.warn("Ignoring dependency with empty version {}:{}.", requested.getGroup(), requested.getName());
-            return;
+            if (isEmpty(resolveDetails.getTarget().getVersion())) {
+                // this is the case with managed dependencies, where version is provided at resolution time
+                logger.warn("Ignoring dependency with empty version {}:{}.", requested.getGroup(), requested.getName());
+                return;
+            } else {
+                version = resolveDetails.getTarget().getVersion();
+                if (!isEmpty(version)) {
+                    resolvedDependenciesRepository.record(new SimpleProjectRef(requested.getGroup(), requested.getName()),
+                            version);
+                }
+            }
         }
 
-        final ProjectVersionRef requestedGAV = withGAV(requested.getGroup(), requested.getName(), requested.getVersion());
+        final ProjectVersionRef requestedGAV = withGAV(requested.getGroup(), requested.getName(), version);
 
         final Map<String, ProjectVersionRef> alignedDependencies = module.getAlignedDependencies();
         final String key = requestedGAV.toString();

--- a/manipulation/src/main/java/org/jboss/gm/manipulation/actions/OverrideDependenciesAction.java
+++ b/manipulation/src/main/java/org/jboss/gm/manipulation/actions/OverrideDependenciesAction.java
@@ -10,8 +10,9 @@ import org.jboss.gm.common.alignment.ManipulationModel;
 public class OverrideDependenciesAction implements Action<Project> {
     private final AlignedDependencyResolver resolver;
 
-    public OverrideDependenciesAction(ManipulationModel correspondingModule) {
-        this.resolver = new AlignedDependencyResolver(correspondingModule);
+    public OverrideDependenciesAction(ManipulationModel correspondingModule,
+            ResolvedDependenciesRepository resolvedDependenciesRepository) {
+        this.resolver = new AlignedDependencyResolver(correspondingModule, resolvedDependenciesRepository);
     }
 
     @Override

--- a/manipulation/src/main/java/org/jboss/gm/manipulation/actions/PublishingPomTransformerAction.java
+++ b/manipulation/src/main/java/org/jboss/gm/manipulation/actions/PublishingPomTransformerAction.java
@@ -15,10 +15,13 @@ import org.jboss.gm.common.alignment.ManipulationModel;
  */
 public class PublishingPomTransformerAction implements Action<Project> {
 
-    private ManipulationModel alignmentConfiguration;
+    private final ManipulationModel alignmentConfiguration;
+    private final ResolvedDependenciesRepository resolvedDependenciesRepository;
 
-    public PublishingPomTransformerAction(ManipulationModel alignmentConfiguration) {
+    public PublishingPomTransformerAction(ManipulationModel alignmentConfiguration,
+            ResolvedDependenciesRepository resolvedDependenciesRepository) {
         this.alignmentConfiguration = alignmentConfiguration;
+        this.resolvedDependenciesRepository = resolvedDependenciesRepository;
     }
 
     @Override
@@ -31,7 +34,7 @@ public class PublishingPomTransformerAction implements Action<Project> {
                 plugin -> project.getExtensions().configure(PublishingExtension.class, extension -> {
                     extension.getPublications().withType(MavenPublication.class).all(maven -> {
                         if (maven.getPom() != null) {
-                            maven.getPom().withXml(new PomTransformer(alignmentConfiguration));
+                            maven.getPom().withXml(new PomTransformer(alignmentConfiguration, resolvedDependenciesRepository));
                         }
                     });
                 }));

--- a/manipulation/src/main/java/org/jboss/gm/manipulation/actions/ResolvedDependenciesRepository.java
+++ b/manipulation/src/main/java/org/jboss/gm/manipulation/actions/ResolvedDependenciesRepository.java
@@ -1,0 +1,23 @@
+package org.jboss.gm.manipulation.actions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.commonjava.maven.atlas.ident.ref.ProjectRef;
+
+/**
+ * Used in order to record the dependencies that don't have a declared version, but a version
+ * that is determined at runtime (by a BOM or the Spring Dependency Management Plugin for example)
+ */
+public class ResolvedDependenciesRepository {
+
+    private Map<ProjectRef, String> gaToVersion = new HashMap<>();
+
+    public void record(ProjectRef projectRef, String version) {
+        gaToVersion.put(projectRef, version);
+    }
+
+    public String get(ProjectRef projectRef) {
+        return gaToVersion.get(projectRef);
+    }
+}

--- a/manipulation/src/main/java/org/jboss/gm/manipulation/actions/UploadTaskTransformerAction.java
+++ b/manipulation/src/main/java/org/jboss/gm/manipulation/actions/UploadTaskTransformerAction.java
@@ -13,10 +13,13 @@ import org.jboss.gm.common.alignment.ManipulationModel;
  */
 public class UploadTaskTransformerAction implements Action<Project> {
 
-    private ManipulationModel alignmentConfiguration;
+    private final ManipulationModel alignmentConfiguration;
+    private final ResolvedDependenciesRepository resolvedDependenciesRepository;
 
-    public UploadTaskTransformerAction(ManipulationModel alignmentConfiguration) {
+    public UploadTaskTransformerAction(ManipulationModel alignmentConfiguration,
+            ResolvedDependenciesRepository resolvedDependenciesRepository) {
         this.alignmentConfiguration = alignmentConfiguration;
+        this.resolvedDependenciesRepository = resolvedDependenciesRepository;
     }
 
     @Override
@@ -27,7 +30,7 @@ public class UploadTaskTransformerAction implements Action<Project> {
 
         project.getTasks().withType(Upload.class).all(upload -> upload.getRepositories()
                 .withType(MavenResolver.class).all(resolver -> {
-                    resolver.getPom().withXml(new PomTransformer(alignmentConfiguration));
+                    resolver.getPom().withXml(new PomTransformer(alignmentConfiguration, resolvedDependenciesRepository));
                 }));
     }
 }


### PR DESCRIPTION
This support only works when the the plugin is configured to NOT
generate a dependencyManagement section in the generated pom (like is
currently the case for Spring Framework)