### PR TITLE
Avoid multiline comments format being destroyed

### DIFF
--- a/ide-config/eclipse-format.xml
+++ b/ide-config/eclipse-format.xml
@@ -64,7 +64,7 @@
     <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
     <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
     <setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="false"/>
-    <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="false"/>
     <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
     <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
     <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>


### PR DESCRIPTION
This avoids the formatter inserting '*' when I just want to comment out a block of code.