### PR TITLE
NCL-4663 Configure publishing of the plugins to the portal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,3 +28,20 @@ select the `eclipse.importorder` file as the import order config file.
 * All external invocation points cannot throw a checked exception so must use an unchecked exception (e.g. `ManipulationUncheckedException`.
 * The `org.gradle.api.InvalidUserDataException` can be used for configuration errors.
 * Avoid throwing `RuntimeException` ; rather, use a more explicit exception.
+
+### Releasing
+
+The project has been configured to release both plugins to the Gradle Portal.
+
+#### Prerequisites
+
+* Sign up for a Gradle account (see details [here](https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/#create_an_account_on_the_gradle_plugin_portal))
+* Create the required `$HOME/.gradle/gradle.properties` locally with data from the API key (which can be found in your gradle account)
+
+#### Release command
+
+The plugins can be released using the following command:
+
+
+	./gradlew publishPlugins -Pversion=whatever
+ 	     

--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -4,11 +4,20 @@ java {
     sourceCompatibility = JavaVersion.VERSION_1_8
 }
 
+
+pluginBundle {
+    description = "Plugin that that generates alignment metadata at \${project.rootDir}/manipulation.json"
+    website = "https://project-ncl.github.io/gradle-manipulator/"
+    vcsUrl = "https://github.com/project-ncl/gradle-manipulator/tree/master/analyzer"
+    tags = listOf("versions", "alignment")
+}
+
 gradlePlugin {
     plugins {
         create("alignmentPlugin") {
             id = "org.jboss.gm.analyzer"
             implementationClass = "org.jboss.gm.analyzer.alignment.AlignmentPlugin"
+            displayName = "gme-analyzer"
         }
     }
 }
@@ -57,8 +66,12 @@ val functionalTest = task<Test>("functionalTest") {
 tasks.check { dependsOn(functionalTest) }
 
 tasks {
+    //this is done in order to use the proper version in the init gradle files
     "processResources"(ProcessResources::class) {
-         filesMatching("gme.gradle") {
+        filesMatching("gme.gradle") {
+            expand(project.properties)
+        }
+        filesMatching("analyzer.init.gradle") {
             expand(project.properties)
         }
     }

--- a/analyzer/src/main/resources/analyzer.init.gradle
+++ b/analyzer/src/main/resources/analyzer.init.gradle
@@ -6,7 +6,7 @@ initscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.jboss.gm.analyzer:analyzer:0.1-SNAPSHOT'
+        classpath "org.jboss.gm.analyzer:analyzer:${project.version}"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+version=0.1-SNAPSHOT

--- a/manipulation/build.gradle.kts
+++ b/manipulation/build.gradle.kts
@@ -4,11 +4,19 @@ java {
     sourceCompatibility = JavaVersion.VERSION_1_8
 }
 
+pluginBundle {
+    description = "Plugin that reads the alignment data from \${project.rootDir}/manipulation.json and configures build and publishing to use those versions"
+    website = "https://project-ncl.github.io/gradle-manipulator/"
+    vcsUrl = "https://github.com/project-ncl/gradle-manipulator/tree/master/manipulation/tree/master/analyzer"
+    tags = listOf("versions", "manipulation")
+}
+
 gradlePlugin {
     plugins {
         create("manipulationPlugin") {
             id = "org.jboss.gm.manipulation"
             implementationClass = "org.jboss.gm.manipulation.ManipulationPlugin"
+            displayName = "gme-manipulation"
         }
     }
 }


### PR DESCRIPTION
The configuration follows the standard gradle suggestions at:
https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/