### PR TITLE
NCL-4726 Export artifact repository settings

### DIFF
--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/ComplexProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/ComplexProjectFunctionalTest.java
@@ -89,6 +89,7 @@ public class ComplexProjectFunctionalTest extends AbstractWiremockTest {
         assertThat(repositories).extracting("url").containsOnly(
                 "https://repo.maven.apache.org/maven2/",
                 "https://oss.sonatype.org/content/repositories/snapshots/",
-                "https://localhost:8089/ivy-repo");
+                "https://localhost:8089/ivy-repo",
+                "https://plugins.gradle.org/m2/");
     }
 }

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/MultiModuleProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/MultiModuleProjectFunctionalTest.java
@@ -127,7 +127,9 @@ public class MultiModuleProjectFunctionalTest extends AbstractWiremockTest {
         List<Repository> repositories = generatedSettings.getProfiles().get(0).getRepositories();
         assertThat(repositories).extracting("url")
                 // should not contain duplicate entries
-                .containsOnly("https://repo.maven.apache.org/maven2/");
+                .containsOnly(
+                        "https://repo.maven.apache.org/maven2/",
+                        "https://plugins.gradle.org/m2/");
     }
 
 }

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/MultiModuleProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/MultiModuleProjectFunctionalTest.java
@@ -12,10 +12,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
+import java.util.List;
 
+import org.apache.maven.settings.Repository;
+import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.io.xpp3.SettingsXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 import org.gradle.api.Project;
 import org.jboss.gm.common.Configuration;
@@ -60,7 +66,7 @@ public class MultiModuleProjectFunctionalTest extends AbstractWiremockTest {
     }
 
     @Test
-    public void ensureAlignmentFileCreatedAndAlignmentTaskRun() throws IOException, URISyntaxException {
+    public void ensureAlignmentFileCreatedAndAlignmentTaskRun() throws IOException, URISyntaxException, XmlPullParserException {
 
         final File projectRoot = tempDir.newFolder("multi-module");
         final ManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
@@ -113,6 +119,15 @@ public class MultiModuleProjectFunctionalTest extends AbstractWiremockTest {
 
         // we care about how many calls are made to DA from an implementation perspective which is why we assert
         verify(1, postRequestedFor(urlEqualTo("/da/rest/v-1/reports/lookup/gavs")));
+
+        // check that generated settings.xml contains correct remote repositories
+        File settingsFile = new File(projectRoot, "settings.xml");
+        SettingsXpp3Reader reader = new SettingsXpp3Reader();
+        Settings generatedSettings = reader.read(new FileInputStream(settingsFile));
+        List<Repository> repositories = generatedSettings.getProfiles().get(0).getRepositories();
+        assertThat(repositories).extracting("url")
+                // should not contain duplicate entries
+                .containsOnly("https://repo.maven.apache.org/maven2/");
     }
 
 }

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/TestUtils.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/TestUtils.java
@@ -36,7 +36,7 @@ public final class TestUtils {
 
         final GradleRunner runner = GradleRunner.create()
                 .withProjectDir(projectRoot)
-                .withArguments("--stacktrace", "--info", AlignmentTask.NAME)
+                .withArguments("--stacktrace", "--info", AlignmentTask.NAME, "-DrepoRemovalBackup=settings.xml")
                 .withDebug(true)
                 .forwardOutput()
                 .withPluginClasspath();

--- a/analyzer/src/functTest/resources/complex-project/build.gradle
+++ b/analyzer/src/functTest/resources/complex-project/build.gradle
@@ -1,3 +1,10 @@
+buildscript {
+    repositories {
+        maven {
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+        }
+    }
+}
 
 plugins {
     // including this plugin directly instead of by an init script, which allows to use the freshly build version
@@ -13,6 +20,18 @@ allprojects {
     repositories {
         mavenLocal()
         mavenCentral()
+        flatDir {
+            dirs = [file("repo/")]
+        }
+        /*maven {
+            url = uri("https://localhost/test-repo1")
+        }
+        maven {
+            url = uri("https://localhost/test-repo2")
+        }*/
+        ivy {
+            url = uri("https://localhost:8089/ivy-repo")
+        }
     }
 
     sourceCompatibility = 1.8

--- a/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/AlignmentTask.java
+++ b/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/AlignmentTask.java
@@ -27,6 +27,7 @@ import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.UnresolvedDependency;
+import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.internal.artifacts.configurations.ConflictResolution;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy;
 import org.gradle.api.tasks.TaskAction;
@@ -63,6 +64,8 @@ public class AlignmentTask extends DefaultTask {
             final String currentProjectVersion = project.getVersion().toString();
 
             cache.addDependencies(project, deps);
+            project.getRepositories().forEach(cache::addRepository);
+            project.getBuildscript().getRepositories().forEach(cache::addRepository);
 
             if (StringUtils.isBlank(project.getGroup().toString()) ||
                     DEFAULT_VERSION.equals(project.getVersion().toString())) {
@@ -104,7 +107,8 @@ public class AlignmentTask extends DefaultTask {
                 logger.info("Completed processing for alignment and writing {} ", cache.toString());
 
                 writeManipulationModel(project.getRootDir(), alignmentModel);
-                writeMarkerFile(project.getRootDir());
+                writeMarkerFile();
+                writeRepositorySettingsFile(cache.getRepositories());
             }
         } catch (ManipulationException e) {
             throw new ManipulationUncheckedException(e);
@@ -113,7 +117,8 @@ public class AlignmentTask extends DefaultTask {
         }
     }
 
-    private void writeMarkerFile(File rootDir) throws IOException {
+    private void writeMarkerFile() throws IOException {
+        File rootDir = getProject().getRootDir();
         File gmeGradle = new File(rootDir, GME);
         File rootGradle = new File(rootDir, Project.DEFAULT_BUILD_FILE);
 
@@ -257,5 +262,26 @@ public class AlignmentTask extends DefaultTask {
                 correspondingModule.getAlignedDependencies().put(d.toString(), newVersion);
             }
         });
+    }
+
+    /**
+     * Writes a maven settings file containing artifact repositories used by this project.
+     */
+    private void writeRepositorySettingsFile(Collection<ArtifactRepository> repositories) {
+        Configuration config = ConfigCache.getOrCreate(Configuration.class);
+
+        // trying to mimick PME behaviour here - export only if repoRemovalBackup is defined and by default place it in
+        // project root
+        String repositoriesFilePath = config.repositoriesFile();
+        if (repositoriesFilePath != null) {
+            File repositoriesFile;
+            if (repositoriesFilePath.equals("settings.xml")) {
+                repositoriesFile = new File(getProject().getRootDir(), repositoriesFilePath);
+            } else {
+                repositoriesFile = new File(config.repositoriesFile());
+            }
+
+            new RepositoryExporter(repositories).export(repositoriesFile);
+        }
     }
 }

--- a/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/RepositoryExporter.java
+++ b/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/RepositoryExporter.java
@@ -1,0 +1,110 @@
+package org.jboss.gm.analyzer.alignment;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.maven.settings.Profile;
+import org.apache.maven.settings.Repository;
+import org.apache.maven.settings.RepositoryPolicy;
+import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.building.DefaultSettingsBuilder;
+import org.commonjava.maven.ext.common.ManipulationException;
+import org.commonjava.maven.ext.common.ManipulationUncheckedException;
+import org.commonjava.maven.ext.io.SettingsIO;
+import org.gradle.api.artifacts.repositories.ArtifactRepository;
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.internal.artifacts.repositories.DefaultMavenLocalArtifactRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Exports artifact repositories in a maven settings format.
+ *
+ * @author Tomas Hofman
+ */
+public class RepositoryExporter {
+
+    private static final Logger logger = LoggerFactory.getLogger(RepositoryExporter.class);
+
+    // only export remote URLs
+    private static final Collection<String> SUPPORTED_SCHEMES = Arrays.asList("http", "https");
+
+    private Settings mavenSettings = new Settings();
+    private Profile mavenProfile = new Profile();
+    private int repositoryCounter = 0;
+    private Set<String> exportedUrls = new HashSet<>();
+
+    public RepositoryExporter(Collection<ArtifactRepository> repositories) {
+        mavenSettings.getProfiles().add(mavenProfile);
+        mavenProfile.setId("generated-by-gme");
+        mavenSettings.addActiveProfile(mavenProfile.getId());
+
+        processRepositories(repositories);
+    }
+
+    public void export(File settingsFile) {
+        SettingsIO settingsWriter = new SettingsIO(new DefaultSettingsBuilder());
+        logger.debug("Writing repository settings into {}", settingsFile.getAbsolutePath());
+        try {
+            settingsWriter.write(mavenSettings, settingsFile);
+        } catch (ManipulationException e) {
+            throw new ManipulationUncheckedException("Could not write repository settings file into "
+                    + settingsFile.getAbsolutePath());
+        }
+    }
+
+    private void processRepositories(Collection<ArtifactRepository> repositories) {
+        for (ArtifactRepository repository : repositories) {
+            if (repository instanceof DefaultMavenLocalArtifactRepository) {
+                DefaultMavenLocalArtifactRepository artifactRepository = (DefaultMavenLocalArtifactRepository) repository;
+                logger.debug("Skipping local maven repository: {}", artifactRepository.getUrl());
+            } else if (repository instanceof MavenArtifactRepository) {
+                MavenArtifactRepository artifactRepository = (MavenArtifactRepository) repository;
+                URI url = artifactRepository.getUrl();
+                if (isSuportedScheme(url)) {
+                    logger.debug("Adding maven repository: {}", url);
+                    addRepository(artifactRepository.getName(), url.toString());
+                } else {
+                    logger.debug("Skipping maven repository with unsupported scheme: {}", url);
+                }
+            } else if (repository instanceof IvyArtifactRepository) {
+                IvyArtifactRepository artifactRepository = (IvyArtifactRepository) repository;
+                URI url = artifactRepository.getUrl();
+                if (isSuportedScheme(url)) {
+                    logger.debug("Adding ivy repository: {}", url);
+                    addRepository(artifactRepository.getName(), url.toString());
+                } else {
+                    logger.debug("Skipping ivy repository with unsupported scheme: {}", url);
+                }
+            } else {
+                logger.debug("Skipping repository of type {}", repository.getClass().getSimpleName());
+            }
+        }
+    }
+
+    private void addRepository(String name, String url) {
+        if (exportedUrls.contains(url)) {
+            // skip URLs we've already seen
+            return;
+        }
+        exportedUrls.add(url);
+
+        String repoId = name + "-" + repositoryCounter++; // counter ensures that the id is unique
+        Repository mavenRepository = new Repository();
+        mavenRepository.setId(repoId);
+        mavenRepository.setName(repoId);
+        mavenRepository.setUrl(url);
+        mavenRepository.setSnapshots(new RepositoryPolicy());
+        mavenRepository.setReleases(new RepositoryPolicy());
+        mavenProfile.addRepository(mavenRepository);
+    }
+
+    private static boolean isSuportedScheme(URI url) {
+        return url.getScheme() != null && SUPPORTED_SCHEMES.contains(url.getScheme().toLowerCase());
+    }
+}

--- a/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/RepositoryExporter.java
+++ b/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/RepositoryExporter.java
@@ -44,6 +44,7 @@ public class RepositoryExporter {
         mavenProfile.setId("generated-by-gme");
         mavenSettings.addActiveProfile(mavenProfile.getId());
 
+        addDefaultRepositories();
         processRepositories(repositories);
     }
 
@@ -106,5 +107,9 @@ public class RepositoryExporter {
 
     private static boolean isSuportedScheme(URI url) {
         return url.getScheme() != null && SUPPORTED_SCHEMES.contains(url.getScheme().toLowerCase());
+    }
+
+    protected void addDefaultRepositories() {
+        addRepository("Gradle Plugin Repository", "https://plugins.gradle.org/m2/");
     }
 }

--- a/common/src/main/java/org/jboss/gm/common/Configuration.java
+++ b/common/src/main/java/org/jboss/gm/common/Configuration.java
@@ -87,6 +87,14 @@ public interface Configuration extends Accessible {
     @DefaultValue("REST")
     DependencyPrecedence dependencyConfiguration();
 
+    /**
+     * Path to a file where project's artifact repositories will be exported in the maven settings format.
+     *
+     * PNC will use this file to configure repository proxying.
+     */
+    @Key("repoRemovalBackup")
+    String repositoriesFile();
+
     class DependencyConverter implements Converter<DependencyPrecedence> {
         /**
          * Converts the given input into an Object of type T.

--- a/common/src/main/java/org/jboss/gm/common/ManipulationCache.java
+++ b/common/src/main/java/org/jboss/gm/common/ManipulationCache.java
@@ -1,14 +1,19 @@
 package org.jboss.gm.common;
 
+import java.net.URL;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 import org.commonjava.maven.ext.common.ManipulationUncheckedException;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.jboss.gm.common.model.ManipulationModel;
 
 /**
@@ -32,6 +37,8 @@ public class ManipulationCache {
     private ArrayDeque<ProjectVersionRef> projectVersionRefs = new ArrayDeque<>();
 
     private Map<Project, Collection<ProjectVersionRef>> projectDependencies = new HashMap<>();
+
+    private Set<ArtifactRepository> repositories = new HashSet<>();
 
     /**
      * Retrieves the cache given any project. It will access the root project, check if the
@@ -125,4 +132,11 @@ public class ManipulationCache {
         return rootProject;
     }
 
+    public void addRepository(ArtifactRepository repository) {
+        repositories.add(repository);
+    }
+
+    public Set<ArtifactRepository> getRepositories() {
+        return repositories;
+    }
 }

--- a/manipulation/src/main/java/org/jboss/gm/manipulation/actions/MavenPublicationRepositoryAction.java
+++ b/manipulation/src/main/java/org/jboss/gm/manipulation/actions/MavenPublicationRepositoryAction.java
@@ -14,6 +14,25 @@ import org.jboss.gm.common.Configuration;
  * Adds a publication repository to the legacy maven plugin.
  *
  * Repository URL and authentication token need to be configured externally.
+ *
+ * Performed configuration is equivalent to following gradle snippet:
+ *
+ * <pre>
+ *     uploadArchives {
+ *         repositories {
+ *             maven {
+ *                 url = System.getProperty('AProxDeployUrl')
+ *                 credentials(HttpHeaderCredentials) {
+ *                     name = "Authorization"
+ *                     value = "Bearer " + System.getProperty('accessToken')
+ *                 }
+ *                 authentication {
+ *                     header(HttpHeaderAuthentication)
+ *                 }
+ *             }
+ *         }
+ *     }
+ * </pre>
  */
 public class MavenPublicationRepositoryAction implements Action<Project> {
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/NCL-4726

This should probably wait until after the first release.

Functionality:

If `-DrepoRemovalBackup=path/to/settings.xml` property is configured, `settings.xml` file will be generated and will contain remote repositories used by the project. This file will be picked by PNC in order to automatically configure repository proxying. (I hope I got this right, that is what PME does.)

The property name `repoRemovalBackup` is the same as in PME (respectively PME is accepting two variants, camel case or dashed).