### PR TITLE
Make application of gme.gradle the first that happens in build.gradle

### DIFF
--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/ComplexProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/ComplexProjectFunctionalTest.java
@@ -63,7 +63,7 @@ public class ComplexProjectFunctionalTest extends AbstractWiremockTest {
         final ManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
+        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getNthLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE), 2).trim());
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
             assertThat(am.getGroup()).isEqualTo("org.jboss.gm.analyzer.functest");

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/GrpcLikeLayoutFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/GrpcLikeLayoutFunctionalTest.java
@@ -66,7 +66,7 @@ public class GrpcLikeLayoutFunctionalTest extends AbstractWiremockTest {
         final ManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
+        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getNthLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE), 2).trim());
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
             assertThat(am.getGroup()).isEqualTo(null);

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/InvalidProjectPassFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/InvalidProjectPassFunctionalTest.java
@@ -73,7 +73,7 @@ public class InvalidProjectPassFunctionalTest extends AbstractWiremockTest {
         final ManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
+        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getNthLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE), 2).trim());
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
             assertThat(am.getGroup()).isEqualTo("org.jboss.gm.analyzer.functest");

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/MultiModuleProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/MultiModuleProjectFunctionalTest.java
@@ -72,7 +72,7 @@ public class MultiModuleProjectFunctionalTest extends AbstractWiremockTest {
         final ManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
+        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getNthLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE), 2).trim());
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
             assertThat(am.getGroup()).isEqualTo("org.acme");

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleExistingManipulationProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleExistingManipulationProjectFunctionalTest.java
@@ -68,7 +68,7 @@ public class SimpleExistingManipulationProjectFunctionalTest extends AbstractWir
         final ManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName(), false);
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
+        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getNthLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE), 2).trim());
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
             assertThat(am.getGroup()).isEqualTo("org.acme.gradle");
@@ -106,7 +106,7 @@ public class SimpleExistingManipulationProjectFunctionalTest extends AbstractWir
         final ManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName(), false);
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
+        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getNthLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE), 2).trim());
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
             assertThat(am.getGroup()).isEqualTo("org.acme.gradle");

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleProjectFunctionalTest.java
@@ -56,7 +56,7 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
         final ManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
+        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getNthLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE), 2).trim());
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
             assertThat(am.getGroup()).isEqualTo("org.acme.gradle");

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleProjectWithSpringDMPluginFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleProjectWithSpringDMPluginFunctionalTest.java
@@ -55,7 +55,7 @@ public class SimpleProjectWithSpringDMPluginFunctionalTest extends AbstractWirem
         final ManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
+        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getNthLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE), 2).trim());
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
             assertThat(am.getGroup()).isEqualTo("org.acme.gradle");

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SpringLikeLayoutFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SpringLikeLayoutFunctionalTest.java
@@ -66,7 +66,7 @@ public class SpringLikeLayoutFunctionalTest extends AbstractWiremockTest {
         final ManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
+        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getNthLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE), 2).trim());
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
             assertThat(am.getGroup()).isEqualTo("org.acme");

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/VersionConflictProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/VersionConflictProjectFunctionalTest.java
@@ -56,7 +56,7 @@ public class VersionConflictProjectFunctionalTest extends AbstractWiremockTest {
         final ManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
+        assertEquals(AlignmentTask.LOAD_GME, FileUtils.getNthLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE), 2).trim());
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
             assertThat(am.getGroup()).isEqualTo("org.acme.gradle");

--- a/common/src/main/java/org/jboss/gm/common/utils/FileUtils.java
+++ b/common/src/main/java/org/jboss/gm/common/utils/FileUtils.java
@@ -1,21 +1,27 @@
 package org.jboss.gm.common.utils;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
-
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
-import java.nio.charset.Charset;
-
-import org.apache.commons.io.input.ReversedLinesFileReader;
 
 public class FileUtils {
-    public static String getLastLine(File target) throws IOException {
-        String line = "";
-        try (ReversedLinesFileReader rFile = new ReversedLinesFileReader(target, Charset.defaultCharset())) {
-            while (isBlank(line)) {
-                line = rFile.readLine();
+
+    /**
+     * Read the n-th line of a file (n starts from 1)
+     * Returns null of the line does not exist
+     */
+    public static String getNthLine(File target, int n) throws IOException {
+        try (BufferedReader br = new BufferedReader(new FileReader(target))) {
+            String line = null;
+            int i = 0;
+            while ((i < n) && ((line = br.readLine()) != null)) {
+                i++;
             }
+            if (i == n) {
+                return line;
+            }
+            return null;
         }
-        return line;
     }
 }


### PR DESCRIPTION
We do this in order to apply the plugin early. This is needed in order
to overcome issues with zip tasks that read the are configured
very early and use the project version