### PR TITLE
Fix broken tests

### DIFF
--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleProjectFunctionalTest.java
@@ -115,6 +115,8 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
                     .satisfies(root -> assertThat(root.getVersion()).isEqualTo("1.0.1.redhat-00002"));
         });
 
+        // ensure we don't try to apply the manipulation plugin which in all likelihood isn't even available on the classpath
+        System.setProperty("org.gradle.project.gmeAnalyse", "true");
         GradleRunner.create()
                 .withProjectDir(projectRoot)
                 .withArguments("--stacktrace", "--info", AlignmentTask.NAME)

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleProjectFunctionalTest.java
@@ -136,13 +136,7 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
         });
         assertEquals(AlignmentTask.INJECT_GME_START, org.jboss.gm.common.utils.FileUtils.getFirstLine(lines));
 
-        int counter = 0;
-        for (String l : lines) {
-            if (l.trim().equals(AlignmentTask.INJECT_GME_START)) {
-                counter++;
-            }
-        }
-        assertEquals(1, counter);
+        assertThat(lines).filteredOn(l -> l.startsWith(AlignmentTask.INJECT_GME_START)).hasSize(1);
     }
 
 }

--- a/analyzer/src/main/resources/gme.gradle
+++ b/analyzer/src/main/resources/gme.gradle
@@ -25,7 +25,7 @@ buildscript {
     // this flag is used to disable the execution of the manipulation plugin
     // after the analyzer plugin has already run on the projects
     // This avoids issues with rerunning in local environments and also in
-    // tests when we don't want to apply the manipilation plugin, but
+    // tests when we don't want to apply the manipulation plugin, but
     // just rerun the analyzer plugin
     if (!project.hasProperty("gmeAnalyse")) {
         dependencies {

--- a/analyzer/src/main/resources/gme.gradle
+++ b/analyzer/src/main/resources/gme.gradle
@@ -22,14 +22,19 @@ buildscript {
         }
     }
 
-    dependencies {
-        classpath "org.jboss.gm.manipulation:manipulation:${project.version}"
+    // this flag is used to disable the execution of the manipulation plugin
+    // after the analyzer plugin has already run on the projects
+    // This avoids issues with rerunning in local environments and also in
+    // tests when we don't want to apply the manipilation plugin, but
+    // just rerun the analyzer plugin
+    if (!project.hasProperty("gmeAnalyse")) {
+        dependencies {
+            classpath "org.jboss.gm.manipulation:manipulation:${project.version}"
+        }
     }
 }
 
 allprojects {
-    // If we are not running the analyse plugin then apply the manipulation plugin.
-    // This avoids issues with rerunning in local environments.
     if (!project.hasProperty("gmeAnalyse")) {
         logger.info("Applying plugin org.jboss.gm.manipulation.ManipulationPlugin")
         apply plugin: org.jboss.gm.manipulation.ManipulationPlugin


### PR DESCRIPTION
Apply the `gmeAnalyse` property to the classpath in `gme.gradle` as well
to ensure that the manipulation plugin is not looked up when not needed