### PR TITLE
Set SystemErrRule to be static to mask harmless warning messages on s…

### DIFF
--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/AbstractWiremockTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/AbstractWiremockTest.java
@@ -11,14 +11,16 @@ import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.StdErrLog;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.contrib.java.lang.system.SystemErrRule;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 public abstract class AbstractWiremockTest {
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule();
+    @ClassRule
+    public static final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
 
     @BeforeClass
     public static void beforeClass() {
@@ -26,6 +28,9 @@ public abstract class AbstractWiremockTest {
         el.setLevel(10);
         Log.setLog(el);
     }
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule();
 
     @Before
     public void before() {

--- a/common/src/main/java/org/jboss/gm/common/Configuration.java
+++ b/common/src/main/java/org/jboss/gm/common/Configuration.java
@@ -131,10 +131,10 @@ public interface Configuration extends Accessible, Reloadable {
          */
         @Override
         public DependencyPrecedence convert(Method method, String input) {
-            if (isEmpty(input)) {
-                return DependencyPrecedence.NONE;
+            if (input != null) {
+                input = input.toUpperCase();
             }
-            return DependencyPrecedence.valueOf(input.toUpperCase());
+            return DependencyPrecedence.valueOf(input);
         }
     }
 

--- a/common/src/main/java/org/jboss/gm/common/logging/FilteringCustomLogger.java
+++ b/common/src/main/java/org/jboss/gm/common/logging/FilteringCustomLogger.java
@@ -43,11 +43,10 @@ public class FilteringCustomLogger implements OutputEventListener {
         LogEvent logEvent = (LogEvent) event;
         if (ignoreCategories.stream().noneMatch(i -> logEvent.getCategory().startsWith(i))) {
             if (acceptableCategories.stream().noneMatch(i -> logEvent.getCategory().startsWith(i))) {
-                // Can't use logger to output the warning as causes stack overflow.
+                // Can't use logger to output a warning as causes stack overflow.
                 // TODO: Remove?
                 // System.err.println("Unknown event using category " + logEvent.getCategory() + " : ");
                 delegate.onOutput(event);
-                // System.err.println(".... completed unknown event.");
             }
             delegate.onOutput(event);
         }


### PR DESCRIPTION
…uccessful tests. Ensure project connections are closed correctly. Handle build exceptions better. Better handling for DependencyPrecedence. Set daemonMaxIdleTime to low value to avoid incorrect values being cached.