### PR TITLE
Remove trailing whitespace from version string

### DIFF
--- a/common/src/main/java/org/jboss/gm/common/utils/ManifestUtils.java
+++ b/common/src/main/java/org/jboss/gm/common/utils/ManifestUtils.java
@@ -32,7 +32,7 @@ public class ManifestUtils {
                     result = manifest.getMainAttributes()
                             .getValue("Implementation-Version");
                     result += " ( SHA: " + manifest.getMainAttributes()
-                            .getValue("Scm-Revision") + " ) ";
+                            .getValue("Scm-Revision") + " )";
                     break;
                 }
             }


### PR DESCRIPTION
This is also leading to two spaces between words instead of one when this is concatenated elsewhere in the code.