### PR TITLE
Add .gitattributes to work around spotless issue with eol

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 * text=auto
 * text eol=lf
+*.bat text eol=crlf
+*.jar binary


### PR DESCRIPTION
See <https://github.com/diffplug/spotless/issues/39>.