### PR TITLE
[NCL-6167] Use new PME/DA endpoint parameters

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,7 +129,7 @@ subprojects {
     extra["logbackVersion"] = "1.2.3"
     extra["mavenVersion"] = "3.5.0"
     extra["ownerVersion"] = "1.0.12"
-    extra["pmeVersion"] = "4.2"
+    extra["pmeVersion"] = "4.3"
     extra["slf4jVersion"] = "1.7.30"
     extra["systemRulesVersion"] = "1.19.0"
 

--- a/common/src/main/java/org/jboss/gm/common/Configuration.java
+++ b/common/src/main/java/org/jboss/gm/common/Configuration.java
@@ -189,6 +189,23 @@ public interface Configuration extends Accessible, Reloadable {
     @DefaultValue("false")
     boolean reportNonAligned();
 
+    /**
+     * Indicates whether we want to search for artifacts in brew or not.
+     * Default value: false
+     */
+    @Key("restBrewPullActive")
+    @DefaultValue("false")
+    boolean restBrewPullActive();
+
+    /**
+     * Mode of the artifacts to align. For temporary builds, the mode is: 'TEMPORARY', 'PERSISTENT' for permanent,
+     * 'SERVICE' for service builds, and 'SERVICE-TEMPORARY' for temporary service builds .
+     * Default value: empty string
+     */
+    @Key("restMode")
+    @DefaultValue("")
+    String restMode();
+
     class DependencyConverter implements Converter<DependencyPrecedence> {
         /**
          * Converts the given input into an Object of type T.

--- a/common/src/main/java/org/jboss/gm/common/groovy/BaseScript.java
+++ b/common/src/main/java/org/jboss/gm/common/groovy/BaseScript.java
@@ -104,7 +104,7 @@ public abstract class BaseScript extends GradleBaseScript {
         return fileIO;
     }
 
-    // TODO: @Override from PME
+    @Override
     public Translator getRESTAPI() {
         return restAPI;
     }

--- a/common/src/main/java/org/jboss/gm/common/utils/RESTUtils.java
+++ b/common/src/main/java/org/jboss/gm/common/utils/RESTUtils.java
@@ -27,6 +27,8 @@ public class RESTUtils {
                     configuration.restMaxSize(),
                     Translator.CHUNK_SPLIT_COUNT,
                     configuration.restRepositoryGroup(),
+                    configuration.restBrewPullActive(),
+                    configuration.restMode(),
                     configuration.versionIncrementalSuffix(),
                     configuration.restHeaders(),
                     configuration.restConnectionTimeout(),


### PR DESCRIPTION
The new PME (4.3) and DA (2.x) introduces 2 new parameters:

- brewPullActive (default: false)
- mode (default: "")

The 'brewPullActive' flag is set on whether to also consider artifacts
from Brew during alignment.

The mode is used to specify to which aligned versions to align to. Currently
there are 4 modes:

- PERSISTENT (permanent aligned builds)
- TEMPORARY (temporary aligned builds)
- SERVICE (service aligned builds)
- SERVICE-TEMPORARY (temporary service aligned builds)

Those modes and the corresponding aligned version suffixes are
configured on the Dependency Analysis service.
