### PR TITLE
Preserve order of JVM args

### DIFF
--- a/cli/src/main/java/org/jboss/gm/cli/Main.java
+++ b/cli/src/main/java/org/jboss/gm/cli/Main.java
@@ -3,6 +3,7 @@ package org.jboss.gm.cli;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -196,7 +197,7 @@ public class Main implements Callable<Void> {
             BuildLauncher build = connection.newBuild();
             Set<String> jvmArgs = jvmPropertyParams.entrySet().stream()
                     .map(entry -> "-D" + entry.getKey() + '=' + entry.getValue())
-                    .collect(Collectors.toSet());
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
 
             if (colour && StringUtils.isEmpty(System.getenv("NO_COLOR"))) {
                 build.setColorOutput(true);

--- a/cli/src/test/java/org/jboss/gm/cli/MainTest.java
+++ b/cli/src/test/java/org/jboss/gm/cli/MainTest.java
@@ -113,8 +113,8 @@ public class MainTest {
 
         Main m = new Main();
         String[] args = new String[] { "-t", projectRoot.getParentFile().getAbsolutePath(), "tasks",
-                "-DgroovyScripts=" + groovy.toString(),
-                "-DdependencyOverride.org.jboss.slf4j:*@*=" };
+                "-DdependencyOverride.org.jboss.slf4j:*@*=",
+                "-DgroovyScripts=" + groovy };
         m.run(args);
 
         assertTrue(systemOutRule.getLog().contains("Running Groovy script on"));
@@ -135,7 +135,7 @@ public class MainTest {
 
         Main m = new Main();
         String[] args = new String[] { "-d", "-t", projectRoot.getParentFile().getAbsolutePath(), "tasks",
-                "-DgroovyScripts=" + groovy.toString(),
+                "-DgroovyScripts=" + groovy,
                 "-DdependencyOverride.org.jboss.slf4j:*@*=",
                 "-Dmanipulation.disable=true" };
         m.run(args);
@@ -259,8 +259,8 @@ public class MainTest {
 
         Main m = new Main();
         String[] args = new String[] { "--no-colour", "-t", projectRoot.getParentFile().getAbsolutePath(), "tasks",
-                "-DgroovyScripts=" + groovy.toString(),
-                "-DdependencyOverride.org.jboss.slf4j:*@*=", "--no-colour" };
+                "-DdependencyOverride.org.jboss.slf4j:*@*=",
+                "-DgroovyScripts=" + groovy };
         m.run(args);
 
         assertTrue(systemOutRule.getLog().contains("Running Groovy script on"));
@@ -285,7 +285,7 @@ public class MainTest {
     }
 
     @Test
-    public void testGradleInvalidTarget2() throws IOException {
+    public void testGradleInvalidTarget2() {
         Main m = new Main();
         String[] args = new String[] { "-t", UUID.randomUUID().toString() };
         try {


### PR DESCRIPTION
The order of JVM args passed on the command line should be in a predictable order.

The `Map` `jvmPropertyParams` correctly preserves the order of passed JVM parameters on the command line as it is a `LinkedHashMap`. However, then a `Set`  `jvmArgs` is created from the `Map` and the original order is immediately lost. This changes from `Collectors.toSet()` to `Collectors.toCollection(LinkedHashSet::new)` to maintain the order of the elements.

`MainTest` could have caught this. It expects the JVM arg `-DdependencyOverride.org.jboss.slf4j:*@*="` to be first every time, but this appears to be a coincidence since it's not even the first one added.