### PR TITLE
Explicitly specify gradle-build-action version

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -47,7 +47,7 @@ jobs:
       # net.linguica.gradle.maven.settings plugin and github's provided maven
       # settings.xml file
       run: rm ~/.m2/settings.xml
-    - uses: gradle/gradle-build-action@v2
+    - uses: gradle/gradle-build-action@v2.1.7
       with:
         gradle-version: ${{ matrix.gradle }}
         arguments: --no-daemon --stacktrace clean build AggregateJacocoReport


### PR DESCRIPTION
This is to workaround https://github.com/gradle/gradle-build-action/issues/350 