### PR TITLE
Add support for Gradle 7.4.2

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gradle: [4.10.3, "5.0", 5.1.1, 5.2.1, 5.3.1, 5.4.1, 5.5.1, 5.6.4, 6.0.1, 6.1.1, 6.2.2, 6.3, 6.4.1, 6.5.1, 6.6.1, 6.7.1, 6.8.3, 6.9.1, 7.0.2, 7.1.1, 7.2, 7.3.3, 7.4]
+        gradle: [4.10.3, "5.0", 5.1.1, 5.2.1, 5.3.1, 5.4.1, 5.5.1, 5.6.4, 6.0.1, 6.1.1, 6.2.2, 6.3, 6.4.1, 6.5.1, 6.6.1, 6.7.1, 6.8.3, 6.9.1, 7.0.2, 7.1.1, 7.2, 7.3.3, 7.4.2]
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif
     if: github.repository == 'project-ncl/gradle-manipulator' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/ComplexProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/ComplexProjectFunctionalTest.java
@@ -110,10 +110,19 @@ public class ComplexProjectFunctionalTest extends AbstractWiremockTest {
             SettingsXpp3Reader settingsXpp3Reader = new SettingsXpp3Reader();
             Settings generatedSettings = settingsXpp3Reader.read(reader);
             List<Repository> repositories = generatedSettings.getProfiles().get(0).getRepositories();
-            assertThat(repositories).extracting("url").containsOnly(
-                    "https://repo.maven.apache.org/maven2/",
-                    "https://oss.sonatype.org/content/repositories/snapshots/",
-                    "https://dl.google.com/dl/android/maven2/");
+
+            if (GradleVersion.current().compareTo(GradleVersion.version("7.4")) <= 0) {
+                assertThat(repositories).extracting("url").containsOnly(
+                        "https://repo.maven.apache.org/maven2/",
+                        "https://oss.sonatype.org/content/repositories/snapshots/",
+                        "https://dl.google.com/dl/android/maven2/");
+            } else {
+                assertThat(repositories).extracting("url").containsOnly(
+                        "https://repo.maven.apache.org/maven2/",
+                        "https://plugins.gradle.org/m2",
+                        "https://oss.sonatype.org/content/repositories/snapshots/",
+                        "https://dl.google.com/dl/android/maven2/");
+            }
         }
     }
 }

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/MultiModuleProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/MultiModuleProjectFunctionalTest.java
@@ -24,6 +24,7 @@ import org.commonjava.maven.ext.common.json.PME;
 import org.commonjava.maven.ext.common.util.JSONUtils;
 import org.commonjava.maven.ext.io.rest.DefaultTranslator;
 import org.gradle.api.Project;
+import org.gradle.util.GradleVersion;
 import org.jboss.gm.analyzer.alignment.TestUtils.TestManipulationModel;
 import org.jboss.gm.common.Configuration;
 import org.jboss.gm.common.utils.FileUtils;
@@ -143,10 +144,19 @@ public class MultiModuleProjectFunctionalTest extends AbstractWiremockTest {
             SettingsXpp3Reader settingsXpp3Reader = new SettingsXpp3Reader();
             Settings generatedSettings = settingsXpp3Reader.read(reader);
             List<Repository> repositories = generatedSettings.getProfiles().get(0).getRepositories();
-            assertThat(repositories).extracting("url")
-                    // should not contain duplicate entries
-                    .containsOnly(
-                            "https://repo.maven.apache.org/maven2/");
+
+            if (GradleVersion.current().compareTo(GradleVersion.version("7.4")) <= 0) {
+                assertThat(repositories).extracting("url")
+                        // should not contain duplicate entries
+                        .containsOnly(
+                                "https://repo.maven.apache.org/maven2/");
+            } else {
+                assertThat(repositories).extracting("url")
+                        // should not contain duplicate entries
+                        .containsOnly(
+                                "https://repo.maven.apache.org/maven2/",
+                                "https://plugins.gradle.org/m2");
+            }
         }
 
         // make sure the project name was not changed

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/MultiModuleProjectWithOverridesFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/MultiModuleProjectWithOverridesFunctionalTest.java
@@ -23,6 +23,7 @@ import org.commonjava.maven.ext.common.ManipulationException;
 import org.commonjava.maven.ext.io.rest.DefaultTranslator;
 import org.gradle.api.Project;
 import org.gradle.internal.Pair;
+import org.gradle.util.GradleVersion;
 import org.jboss.gm.analyzer.alignment.TestUtils.TestManipulationModel;
 import org.jboss.gm.common.Configuration;
 import org.jboss.gm.common.utils.FileUtils;
@@ -172,10 +173,19 @@ public class MultiModuleProjectWithOverridesFunctionalTest
             SettingsXpp3Reader settingsXpp3Reader = new SettingsXpp3Reader();
             Settings generatedSettings = settingsXpp3Reader.read(reader);
             List<Repository> repositories = generatedSettings.getProfiles().get(0).getRepositories();
-            assertThat(repositories).extracting("url")
-                    // should not contain duplicate entries
-                    .containsOnly(
-                            "https://repo.maven.apache.org/maven2/");
+
+            if (GradleVersion.current().compareTo(GradleVersion.version("7.4")) <= 0) {
+                assertThat(repositories).extracting("url")
+                        // should not contain duplicate entries
+                        .containsOnly(
+                                "https://repo.maven.apache.org/maven2/");
+            } else {
+                assertThat(repositories).extracting("url")
+                        // should not contain duplicate entries
+                        .containsOnly(
+                                "https://repo.maven.apache.org/maven2/",
+                                "https://plugins.gradle.org/m2");
+            }
         }
 
         // make sure the project name was not changed


### PR DESCRIPTION
It looks like in Gradle 7.4.1+ that "https://plugins.gradle.org/m2" was added to the default repository list. Maybe it would be cleaner to make the repository list a constant for the alignment tests, but I didn't see a good place to put it.