### PR TITLE
Don't bother overwriting manifest version values if they haven't changed

### DIFF
--- a/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/bson/build.gradle
+++ b/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/bson/build.gradle
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+archivesBaseName = 'bson'
+description = 'The BSON library'
+
+ext {
+    pomName = 'BSON'
+    pomURL = 'https://bsonspec.org'
+}
+
+jar.manifest.attributes['Import-Package'] = 'org.slf4j.*;resolution:=optional'

--- a/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/bson/src/main/org/bson/Bits.java
+++ b/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/bson/src/main/org/bson/Bits.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Utility class for reading values from an input stream.
+ */
+public class Bits {
+
+    /**
+     * Reads bytes from the input stream and puts them into the given byte buffer. The equivalent of calling
+     * {@link #readFully(java.io.InputStream, byte[], int, int)} with an offset of zero and a length equal to the length of the buffer.
+     *
+     * @param inputStream the input stream to read from
+     * @param buffer      the buffer into which the data is read.
+     * @throws IOException if there's an error reading from the {@code inputStream}
+     */
+    static void readFully(final InputStream inputStream, final byte[] buffer)
+    throws IOException {
+        readFully(inputStream, buffer, 0, buffer.length);
+    }
+
+    /**
+     * Reads bytes from the input stream and puts them into the given byte buffer.
+     *
+     * @param inputStream the input stream to read from
+     * @param buffer      the buffer into which the data is read.
+     * @param offset      the start offset in array {@code buffer} at which the data is written.
+     * @param length      the maximum number of bytes to read.
+     * @throws IOException if there's an error reading from the {@code inputStream}
+     * @see java.io.InputStream#read(byte[], int, int)
+     */
+    static void readFully(final InputStream inputStream, final byte[] buffer, final int offset, final int length)
+    throws IOException {
+        if (buffer.length < length + offset) {
+            throw new IllegalArgumentException("Buffer is too small");
+        }
+
+        int arrayOffset = offset;
+        int bytesToRead = length;
+        while (bytesToRead > 0) {
+            int bytesRead = inputStream.read(buffer, arrayOffset, bytesToRead);
+            if (bytesRead < 0) {
+                throw new EOFException();
+            }
+            bytesToRead -= bytesRead;
+            arrayOffset += bytesRead;
+        }
+    }
+
+    /**
+     * Reads and returns a single integer value from the input stream.
+     *
+     * @param inputStream the input stream to read from
+     * @param buffer the buffer to write the input stream bytes into
+     * @return the integer value
+     * @throws IOException if there's an error reading from the {@code inputStream}
+     */
+    static int readInt(final InputStream inputStream, final byte[] buffer) throws IOException {
+        readFully(inputStream, buffer, 0, 4);
+        return readInt(buffer);
+    }
+
+    /**
+     * Reads and returns a single integer value from the buffer. The equivalent of calling {@link #readInt(byte[], int)}
+     * with an offset of zero.
+     *
+     * @param buffer the buffer to read from
+     * @return the integer value
+     */
+    static int readInt(final byte[] buffer) {
+        return readInt(buffer, 0);
+    }
+
+    /**
+     * Reads and returns a single integer value from the buffer.
+     *
+     * @param buffer the buffer to read from
+     * @param offset the position to start reading from the buffer
+     * @return the integer value
+     */
+    static int readInt(final byte[] buffer, final int offset) {
+        int x = 0;
+        x |= (0xFF & buffer[offset + 0]) << 0;
+        x |= (0xFF & buffer[offset + 1]) << 8;
+        x |= (0xFF & buffer[offset + 2]) << 16;
+        x |= (0xFF & buffer[offset + 3]) << 24;
+        return x;
+    }
+
+    /**
+     * Reads and returns a single long value from the input stream.
+     *
+     * @param inputStream the input stream to read from
+     * @return the long value
+     * @throws IOException if there's an error reading from the {@code inputStream}
+     */
+    static long readLong(final InputStream inputStream) throws IOException {
+        return readLong(inputStream, new byte[8]);
+    }
+
+    /**
+     * Reads and returns a single long value from the input stream.
+     *
+     * @param inputStream the input stream to read from
+     * @param buffer the buffer to write the input stream bytes into
+     * @return the long value
+     * @throws IOException if there's an error reading from the {@code inputStream}
+     */
+    static long readLong(final InputStream inputStream, final byte[] buffer) throws IOException {
+        readFully(inputStream, buffer, 0, 8);
+        return readLong(buffer);
+    }
+
+    /**
+     * Reads and returns a single long value from the buffer. The equivalent of called {@link #readLong(byte[], int)} with an offset of
+     * zero.
+     *
+     * @param buffer the buffer to read from
+     * @return the long value
+     */
+    static long readLong(final byte[] buffer) {
+        return readLong(buffer, 0);
+    }
+
+    /**
+     * Reads and returns a single long value from the buffer.
+     *
+     * @param buffer the buffer to read from
+     * @param offset the position to start reading from the buffer
+     * @return the long value
+     */
+    static long readLong(final byte[] buffer, final int offset) {
+        long x = 0;
+        x |= (0xFFL & buffer[offset + 0]) << 0;
+        x |= (0xFFL & buffer[offset + 1]) << 8;
+        x |= (0xFFL & buffer[offset + 2]) << 16;
+        x |= (0xFFL & buffer[offset + 3]) << 24;
+        x |= (0xFFL & buffer[offset + 4]) << 32;
+        x |= (0xFFL & buffer[offset + 5]) << 40;
+        x |= (0xFFL & buffer[offset + 6]) << 48;
+        x |= (0xFFL & buffer[offset + 7]) << 56;
+        return x;
+    }
+}

--- a/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/build.gradle
+++ b/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/build.gradle
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
+    }
+    dependencies {
+        classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:3.0.3'
+        classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:4.3.1'
+
+        // Scala plugins
+        classpath "com.adtran:scala-multiversion-plugin:1.0.35"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:3.27.1"
+    }
+}
+
+plugins {
+    // including this plugin directly instead of by an init script, which allows to use the freshly build version
+    id 'org.jboss.gm.manipulation'
+    id 'maven-publish'
+}
+allprojects {
+    apply plugin: 'org.jboss.gm.manipulation'
+}
+
+
+//////////////////////////////////////////
+// Common behavior                      //
+//////////////////////////////////////////
+
+ext {
+    configDir = new File(rootDir, 'config')
+    jnrUnixsocketVersion = '0.18'
+    nettyVersion = '4.1.43.Final'
+    snappyVersion = '1.1.4'
+    zstdVersion = '1.3.8-3'
+    mongoCryptVersion = '1.0.1'
+    gitVersion = "" // getGitVersion()
+}
+
+def configDir = ext.configDir
+def coreProjects = subprojects.findAll { !['util'].contains(it.name) }
+def javaProjects = subprojects.findAll { !it.name.contains('scala') }
+def scalaProjects = subprojects.findAll { it.name.contains('scala') }
+def javaMainProjects = javaProjects.findAll { !['util'].contains(it.name) }
+def javaCodeCheckedProjects = javaMainProjects.findAll { !['driver-benchmarks'].contains(it.name) }
+
+configure(coreProjects) {
+    apply plugin: 'idea'
+
+//     evaluationDependsOn(':util')
+    group = 'org.mongodb'
+    version = '4.1.0.temporary-redhat-00001'
+
+    repositories {
+        mavenLocal()
+        google()
+        mavenCentral()
+    }
+}
+
+configure(javaProjects) {
+    apply plugin: 'java-library'
+
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+
+    sourceSets {
+        main {
+            java.srcDirs = ['src/main']
+        }
+    }
+
+    tasks.withType(GenerateModuleMetadata) {
+        enabled = false
+    }
+}
+
+configure(scalaProjects) {
+    apply plugin: 'scala'
+    apply plugin: 'idea'
+    apply plugin: "com.adtran.scala-multiversion-plugin"
+    apply plugin: "com.diffplug.gradle.spotless"
+
+    group = 'org.mongodb.scala'
+
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+
+    dependencies {
+        implementation ('org.scala-lang:scala-library:%scala-version%')
+        implementation ('org.scala-lang:scala-reflect:%scala-version%')
+
+        testImplementation('junit:junit:4.12')
+        testImplementation('org.scalatest:scalatest_%%:3.0.8')
+        testImplementation('org.scalamock:scalamock_%%:4.4.0')
+        testImplementation('ch.qos.logback:logback-classic:1.1.3')
+        testImplementation('org.reflections:reflections:0.9.10')
+    }
+
+
+    spotless {
+        scala {
+            scalafmt('2.0.0').configFile("$configDir/scalafmt.conf")
+        }
+    }
+    compileScala.dependsOn('spotlessApply')
+    compileTestScala.dependsOn('spotlessApply')
+
+    tasks.withType(ScalaCompile) {
+        scalaCompileOptions.deprecation = false
+    }
+
+    if (project.scalaVersion.startsWith("2.13")) {
+        scaladoc {
+            scalaClasspath += files("$rootDir/gradle/scala/lib/scala-ant-2.13.1.jar")
+        }
+    }
+
+    tasks.withType(GenerateModuleMetadata) {
+        enabled = false
+    }
+}
+
+configure(javaMainProjects) {
+    apply plugin: 'nebula.optional-base'
+    apply plugin: 'java-library'
+
+    dependencies {
+        compileOnly 'com.google.code.findbugs:jsr305:1.3.9'
+        api 'org.slf4j:slf4j-api:1.7.6', optional
+        testImplementation 'com.google.code.findbugs:jsr305:1.3.9'
+    }
+
+    /* Compiling */
+    tasks.withType(AbstractCompile) {
+        options.encoding = 'ISO-8859-1'
+        options.fork = true
+        options.debug = true
+        options.compilerArgs = ['-Xlint:all']
+    }
+}
+
+configure(javaCodeCheckedProjects) {
+    apply plugin: 'checkstyle'
+    apply plugin: 'jacoco'
+    apply plugin: 'groovy'
+    apply plugin: 'codenarc'
+
+    dependencies {
+        testImplementation 'org.codehaus.groovy:groovy-all:2.4.15'
+        testImplementation 'org.spockframework:spock-core:1.1-groovy-2.4'
+        testImplementation 'cglib:cglib-nodep:2.2.2'
+        testImplementation 'org.objenesis:objenesis:1.3'
+        testImplementation 'org.hamcrest:hamcrest-all:1.3'
+        testImplementation 'ch.qos.logback:logback-classic:1.1.1'
+//        testImplementation project(':util') //Adding categories to classpath
+    }
+
+    sourceSets {
+        test {
+            groovy.srcDirs = ['src/test/functional', 'src/test/unit', 'src/test/tck']
+        }
+    }
+
+    /* Testing */
+    tasks.withType(Test) {
+        maxHeapSize = "4g"
+        maxParallelForks = 1
+
+        systemProperties(
+                'org.mongodb.test.uri': System.getProperty('org.mongodb.test.uri'),
+                'org.mongodb.test.transaction.uri': System.getProperty('org.mongodb.test.transaction.uri'),
+                'org.mongodb.useSocket': System.getProperty('org.mongodb.useSocket', 'false'),
+                'org.mongodb.disableAsync': System.getProperty('org.mongodb.disableAsync', 'false'),
+                'org.mongodb.test.async.type': System.getProperty('org.mongodb.test.async.type', 'nio2'),
+                'org.mongodb.test.awsAccessKeyId': System.getProperty('org.mongodb.test.awsAccessKeyId'),
+                'org.mongodb.test.awsSecretAccessKey': System.getProperty('org.mongodb.test.awsSecretAccessKey'),
+                'jna.library.path': System.getProperty('jna.library.path')
+        )
+
+        project.ext.buildingWith = { propertyName ->
+            project.hasProperty(propertyName) && project.property(propertyName).toBoolean()
+        }
+
+        if (project.buildingWith('ssl.enabled')) {
+            if (project.hasProperty('ssl.keyStoreType')) {
+                systemProperties(
+                        'javax.net.ssl.keyStoreType': project.property('ssl.keyStoreType'),
+                        'javax.net.ssl.keyStore': project.property('ssl.keyStore'),
+                        'javax.net.ssl.keyStorePassword': project.property('ssl.keyStorePassword')
+                )
+            }
+            if (project.hasProperty('ssl.trustStoreType')) {
+                systemProperties(
+                        'javax.net.ssl.trustStoreType': project.property('ssl.trustStoreType'),
+                        'javax.net.ssl.trustStore': project.property('ssl.trustStore'),
+                        'javax.net.ssl.trustStorePassword': project.property('ssl.trustStorePassword')
+                )
+            }
+            if (project.hasProperty('ocsp.property')) {
+                systemProperties(
+                    'org.mongodb.test.ocsp.tls.should.succeed': project.property('ocsp.tls.should.succeed'),
+                    'java.security.properties': file(project.property('ocsp.property')),
+                    'com.sun.net.ssl.checkRevocation': project.property('ssl.checkRevocation'),
+                    'jdk.tls.client.enableStatusRequestExtension': project.property('client.enableStatusRequestExtension'),
+                    'jdk.tls.client.protocols': project.property('client.protocols')
+                )
+            }
+        }
+
+        if (project.buildingWith('gssapi.enabled')) {
+            systemProperties(
+                    'sun.security.krb5.debug': project.getProperty('sun.security.krb5.debug'),
+                    'javax.security.auth.useSubjectCredsOnly': "false",
+                    'java.security.krb5.kdc': project.getProperty('krb5.kdc'),
+                    'java.security.krb5.realm': project.getProperty('krb5.realm'),
+                    'java.security.auth.login.config': project.getProperty('auth.login.config'),
+                    )
+        }
+
+        useJUnit {
+            excludeCategories 'category.Slow'
+        }
+
+        jacoco { enabled = false }
+
+        testLogging { exceptionFormat = 'full' }
+    }
+
+    task testSlowOnly(type: Test) {
+        useJUnit {
+            includeCategories 'category.Slow'
+        }
+    }
+
+    gradle.taskGraph.whenReady { taskGraph ->
+        if (taskGraph.hasTask(testCoverage)) {
+            tasks.withType(Test) { jacoco { enabled = true } }
+        }
+    }
+
+    task testCoverage(dependsOn: test)
+
+    /* Code quality */
+    tasks.withType(Checkstyle) {
+        reports {
+            xml.enabled true
+            html.enabled true
+        }
+    }
+
+    checkstyle {
+        toolVersion = "7.4"
+        configFile = new File(configDir, 'checkstyle.xml')
+        configProperties.checkstyleConfigDir = configDir
+    }
+
+    codenarc {
+        toolVersion = '1.1'
+        reportFormat = project.buildingWith('xmlReports.enabled') ? 'xml' : 'html'
+    }
+
+    tasks.withType(Test) {
+        def jdkHome = findProperty("jdkHome")
+        if (jdkHome) {
+            def javaExecutablesPath = new File(jdkHome, 'bin')
+            def javaExecutables = [:].withDefault { execName ->
+                def executable = new File(javaExecutablesPath, execName)
+                assert executable.exists() : "There is no ${execName} executable in ${javaExecutablesPath}"
+                executable
+            }
+            executable = javaExecutables.java
+        }
+    }
+}
+
+apply from: 'gradle/publish.gradle'
+// apply from: 'gradle/deploy.gradle'
+// apply from: 'gradle/javadoc.gradle'
+// apply from: 'gradle/testColorOutput.gradle'
+
+
+//////////////////////////////////////////
+// Root project configuration           //
+//////////////////////////////////////////
+wrapper {
+    gradleVersion = '6.0.1'
+}
+
+//if (!JavaVersion.current().isJava9Compatible()) {
+//    throw new GradleException("""
+//        | ERROR:
+//        | JDK ${JavaVersion.VERSION_1_9.getMajorVersion()} is required to build the driver: You are using JDK ${JavaVersion.current().getMajorVersion()}.
+//        |""".stripMargin()
+//    )
+//}

--- a/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/driver-core/build.gradle
+++ b/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/driver-core/build.gradle
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+plugins {
+    id 'de.fuerstenau.buildconfig' version '1.1.8'
+}
+
+archivesBaseName = 'mongodb-driver-core'
+description = '''The Java operations layer for the MongoDB Java Driver.
+ Third parties can wrap this layer to provide custom higher-level APIs'''
+
+ext {
+    pomName = 'MongoDB Java Driver Core'
+}
+
+// Add native-image.properties
+sourceSets.main.resources.srcDirs = ['src/resources']
+
+dependencies {
+    api project(path: ':bson', configuration: 'default')
+
+    implementation "com.github.jnr:jnr-unixsocket:$jnrUnixsocketVersion", optional
+    api "io.netty:netty-buffer:$nettyVersion", optional
+    api "io.netty:netty-transport:$nettyVersion", optional
+    implementation "io.netty:netty-handler:$nettyVersion", optional
+    implementation "org.xerial.snappy:snappy-java:$snappyVersion", optional
+    implementation "com.github.luben:zstd-jni:$zstdVersion", optional
+    implementation "org.mongodb:mongodb-crypt:$mongoCryptVersion", optional
+
+    testImplementation project(':bson').sourceSets.test.output
+}
+
+buildConfig {
+    appName = 'mongo-java-driver'
+    version = project.gitVersion
+
+    clsName = 'MongoDriverVersion'
+    packageName = 'com.mongodb.internal.build'
+}
+
+jar {
+    manifest {
+        attributes("Implementation-Version": version,
+                   "Specification-Version": version)
+    }
+}
+
+afterEvaluate {
+    jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.driver.core'
+    jar.manifest.attributes['Bundle-SymbolicName'] = 'org.mongodb.driver-core'
+    jar.manifest.attributes['Import-Package'] = [
+        'org.bson.*', // unfortunate that this is necessary, but if it's left out then it's not included
+        'javax.crypto.*',
+        'javax.management.*',
+        'javax.naming.*',
+        'javax.net.*',
+        'javax.security.sasl.*',
+        'javax.security.auth.callback.*',
+        'org.ietf.jgss.*',
+        'io.netty.*;resolution:=optional',
+        'org.xerial.snappy.*;resolution:=optional',
+        'com.github.luben.zstd.*;resolution:=optional',
+        'org.slf4j.*;resolution:=optional',
+        'jnr.unixsocket.*;resolution:=optional',
+        'com.mongodb.crypt.capi.*;resolution:=optional'
+    ].join(',')
+}

--- a/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/driver-core/src/resources/META-INF/native-image/org.mongodb/mongodb-driver-core/native-image.properties
+++ b/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/driver-core/src/resources/META-INF/native-image/org.mongodb/mongodb-driver-core/native-image.properties
@@ -1,0 +1,16 @@
+#
+# Copyright 2008-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+Args = --initialize-at-run-time=com.mongodb.UnixServerAddress,com.mongodb.internal.connection.SnappyCompressor

--- a/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/gradle.properties
+++ b/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/gradle.properties
@@ -1,0 +1,21 @@
+#
+# Copyright 2008-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.gradle.daemon=true
+org.gradle.jvmargs=-Duser.country=US -Duser.language=en
+scalaVersions=2.11.12,2.12.10,2.13.1
+defaultScalaVersions=2.13.1
+runOnceTasks=clean,release

--- a/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/gradle/publish.gradle
+++ b/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/gradle/publish.gradle
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Configures publishing of the main java projects
+ */
+
+// Publishing helpers
+ext {
+    configurePom = { project ->
+        { ->
+                name = project.hasProperty('pomName') ? project.getProperty('pomName') : project.name
+                description = project.description
+                url = project.hasProperty('pomURL') ? project.getProperty('pomURL') : 'http://www.mongodb.org'
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                scm {
+                    url = 'https://github.com/mongodb/mongo-java-driver'
+                    connection = 'scm:https://github.com/mongodb/mongo-java-driver.git'
+                    developerConnection = 'scm:git@github.com:mongodb/mongo-java-driver.git'
+                }
+                developers {
+                    developer {
+                        name = 'Various'
+                        organization = 'MongoDB'
+                    }
+                }
+            }
+    }
+    configureMavenRepositories = { project ->
+        { ->
+            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+            def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+            maven {
+                url = project.version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+                credentials {
+                    username project.hasProperty('nexusUsername') ? project.getProperty('nexusUsername') : ''
+                    password project.hasProperty('nexusPassword') ? project.getProperty('nexusPassword') : ''
+                }
+            }
+        }
+    }
+    configureJarManifestAttributes = { project ->
+        { ->
+            manifest.attributes['-exportcontents'] =  "*;-noimport:=true"
+            manifest.attributes['Automatic-Module-Name'] =  project.group + '.' + project.archivesBaseName
+            manifest.attributes['Build-Version'] =  project.gitVersion
+            manifest.attributes['Bundle-Version'] =  project.version
+            manifest.attributes['Bundle-Name'] =  project.archivesBaseName
+            manifest.attributes['Bundle-SymbolicName'] =  project.group + '.' + project.archivesBaseName
+        }
+    }
+}
+
+def scalaProjects = subprojects.findAll { it.name.contains('scala') }
+def javaProjects = subprojects.findAll { !scalaProjects.contains(it) && !['util', 'driver-benchmarks'].contains(it.name) }
+
+configure(javaProjects) { project ->
+    apply plugin: 'biz.aQute.bnd.builder'
+    apply plugin: 'maven-publish'
+
+    task sourcesJar(type: Jar) {
+        from project.sourceSets.main.allJava
+        classifier = 'sources'
+    }
+
+    task javadocJar(type: Jar) {
+        from javadoc
+        classifier = 'javadoc'
+    }
+
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+//                artifactId = project.archivesBaseName
+                from project.components.java
+                artifact sourcesJar
+                artifact javadocJar
+
+            }
+        }
+
+        repositories configureMavenRepositories(project)
+    }
+
+    afterEvaluate {
+        jar configureJarManifestAttributes(project)
+//        publishing.publications.mavenJava.artifactId = project.archivesBaseName
+        publishing.publications.mavenJava.pom configurePom(project)
+    }
+}
+
+configure(scalaProjects) { project ->
+    apply plugin: 'biz.aQute.bnd.builder'
+    apply plugin: 'maven-publish'
+
+    task sourcesJar(type: Jar) {
+        from project.sourceSets.main.allScala
+        classifier = 'sources'
+    }
+
+    task scaladocJar(type: Jar) {
+        from scaladoc
+        classifier = 'javadoc'
+    }
+
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                artifactId = project.archivesBaseName.contains('bson') ? 'mongo-scala-bson' : 'mongo-scala-driver'
+                from project.components.java
+                artifact sourcesJar
+                artifact scaladocJar
+            }
+        }
+
+        repositories configureMavenRepositories(project)
+    }
+
+    afterEvaluate {
+        jar configureJarManifestAttributes(project)
+        publishing.publications.mavenJava.pom configurePom(project)
+    }
+}

--- a/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/manipulation.json
+++ b/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/manipulation.json
@@ -1,0 +1,21 @@
+{
+  "group" : "org.mongodb",
+  "name" : "gradle-manipulator",
+  "projectPathName" : "mongo-java-driver",
+  "version" : "4.1.0.temporary-redhat-00001",
+  "originalVersion" : "4.1.0.temporary-redhat-00001",
+  "children" : {
+    "bson" : {
+      "group" : "org.mongodb",
+      "name" : "bson",
+      "projectPathName" : "bson",
+      "version" : "4.1.0.temporary-redhat-00001"
+    },
+    "driver-core" : {
+      "group" : "org.mongodb",
+      "name" : "driver-core",
+      "projectPathName" : "driver-core",
+      "version" : "4.1.0.temporary-redhat-00001"
+    }
+  }
+}

--- a/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/settings.gradle
+++ b/manipulation/src/functTest/resources/mongo-java-driver-no-overwrite/settings.gradle
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+include ':bson'
+// include ':driver-benchmarks'
+include ':driver-core'
+// include ':driver-legacy'
+// include ':driver-sync'
+// include ':driver-reactive-streams'
+// include ':bson-scala'
+// include ':driver-scala'
+// include ':util'


### PR DESCRIPTION
Although replacing values with identical values as we do now is harmless, it seemed important to not always do it, particularly when the version has not changed (`-DversionModification=false`).

I wonder about logging some of these things (non-changes) at info level as it may be a little too verbose.

I did change some of the log messages to make it more clear (to me) what is happening. I think I'd like to see the project name printed more often so that you don't have to find it in the output by scrolling back. Also, programmatically there's no easy way to get the project context from the log if it's not on the same line for testing purposes.