### PR TITLE
Log plugin removal at info level instead of debug level

### DIFF
--- a/common/src/main/java/org/jboss/gm/common/utils/PluginUtils.java
+++ b/common/src/main/java/org/jboss/gm/common/utils/PluginUtils.java
@@ -160,7 +160,7 @@ public class PluginUtils {
                     }
 
                     if (removed) {
-                        logger.debug("Removed instances of plugin {} with configuration block of {} from {}", plugin,
+                        logger.info("Removed instances of plugin {} with configuration block of {} from {}", plugin,
                                 configTask, buildFile);
                         FileUtils.writeStringToFile(buildFile, content, Charset.defaultCharset());
                     }


### PR DESCRIPTION
I think it would be useful by default to know what the plugin removal option is doing, so I changed the level to INFO from DEBUG.