### PR TITLE
Kotlin generation - avoid recursive configuration copying. Use double…

### DIFF
--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/CruiseControlFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/CruiseControlFunctionalTest.java
@@ -64,7 +64,7 @@ public class CruiseControlFunctionalTest extends AbstractWiremockTest {
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
         assertTrue(new File(projectRoot, AlignmentTask.GRADLE + '/' + AlignmentTask.GME_REPOS).exists());
         assertTrue(new File(projectRoot, AlignmentTask.GME_PLUGINCONFIGS).exists());
-        assertEquals(AlignmentTask.INJECT_GME_START, TestUtils.getLine(projectRoot));
+        assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot));
         assertEquals(AlignmentTask.INJECT_GME_END,
                 org.jboss.gm.common.utils.FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
 

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/DynamicWithLocksProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/DynamicWithLocksProjectFunctionalTest.java
@@ -81,7 +81,6 @@ public class DynamicWithLocksProjectFunctionalTest extends AbstractWiremockTest 
         final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName(), false);
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-
         assertEquals(AlignmentTask.INJECT_GME_START, TestUtils.getLine(projectRoot));
         assertEquals(AlignmentTask.INJECT_GME_END, FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
 
@@ -120,7 +119,7 @@ public class DynamicWithLocksProjectFunctionalTest extends AbstractWiremockTest 
         assertTrue(new File(projectRoot, "gradle.lockfile").exists());
 
         // make sure the project name was added
-        assertEquals("rootProject.name='undertow'",
+        assertEquals("rootProject.name=\"undertow\"",
                 FileUtils.getLastLine(new File(projectRoot, "settings.gradle")));
     }
 }

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/InvalidProjectPassFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/InvalidProjectPassFunctionalTest.java
@@ -78,7 +78,7 @@ public class InvalidProjectPassFunctionalTest extends AbstractWiremockTest {
         final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.INJECT_GME_START, TestUtils.getLine(projectRoot));
+        assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot));
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
             assertThat(am.getGroup()).isEqualTo("org.jboss.gm.analyzer.functest");

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/JavaDataLoaderFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/JavaDataLoaderFunctionalTest.java
@@ -63,7 +63,7 @@ public class JavaDataLoaderFunctionalTest extends AbstractWiremockTest {
         assertThat(new File(projectRoot, AlignmentTask.GME)).exists();
         assertThat(new File(projectRoot, AlignmentTask.GRADLE + '/' + AlignmentTask.GME_REPOS)).exists();
         assertThat(new File(projectRoot, AlignmentTask.GME_PLUGINCONFIGS)).exists();
-        assertThat(TestUtils.getLine(projectRoot)).isEqualTo(AlignmentTask.INJECT_GME_START);
+        assertThat(TestUtils.getLine(projectRoot)).isEqualTo(AlignmentTask.INJECT_GME_START + " }");
         assertThat(FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)))
                 .isEqualTo(AlignmentTask.INJECT_GME_END);
         assertThat(systemOutRule.getLog())

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/MultiModuleProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/MultiModuleProjectFunctionalTest.java
@@ -89,7 +89,7 @@ public class MultiModuleProjectFunctionalTest extends AbstractWiremockTest {
         final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.INJECT_GME_START, TestUtils.getLine(projectRoot));
+        assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot));
         assertEquals(AlignmentTask.INJECT_GME_END, FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/MultiModuleProjectWithOverridesFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/MultiModuleProjectWithOverridesFunctionalTest.java
@@ -109,7 +109,7 @@ public class MultiModuleProjectWithOverridesFunctionalTest
         assertThat(systemOutRule.getLog()).contains("Updating sub-project org.acme:subproject1:null (path: "
                 + "subproject1) from version 1.1.2 to 1.1.2.redhat-00005");
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.INJECT_GME_START, TestUtils.getLine(projectRoot));
+        assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot));
         assertEquals(AlignmentTask.INJECT_GME_END, FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/OpenTelemetryFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/OpenTelemetryFunctionalTest.java
@@ -71,7 +71,7 @@ public class OpenTelemetryFunctionalTest extends AbstractWiremockTest {
         final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.INJECT_GME_START, TestUtils.getLine(projectRoot));
+        assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot));
         assertEquals(AlignmentTask.INJECT_GME_END, FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
@@ -101,7 +101,7 @@ public class OpenTelemetryFunctionalTest extends AbstractWiremockTest {
                 Collections.singletonMap("overrideTransitive", "false"));
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.INJECT_GME_START_KOTLIN, TestUtils.getLine(projectRoot));
+        assertEquals(AlignmentTask.INJECT_GME_START_KOTLIN + " }", TestUtils.getLine(projectRoot));
         assertEquals(AlignmentTask.INJECT_GME_END_KOTLIN,
                 FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE + ".kts")));
 

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/PGJDBCKotlinFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/PGJDBCKotlinFunctionalTest.java
@@ -3,6 +3,8 @@ package org.jboss.gm.analyzer.alignment;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.util.List;
 
 import org.commonjava.maven.ext.common.ManipulationException;
 import org.commonjava.maven.ext.io.rest.DefaultTranslator;
@@ -78,13 +80,15 @@ public class PGJDBCKotlinFunctionalTest extends AbstractWiremockTest {
         assumeTrue(GradleVersion.current().compareTo(GradleVersion.version("5.3")) >= 0);
 
         final File projectRoot = tempDir.newFolder("pgjdbc");
+        final File buildFile = new File(projectRoot, "build.gradle.kts");
         final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
         assertTrue(new File(projectRoot, AlignmentTask.GRADLE + '/' + AlignmentTask.GME_REPOS).exists());
         assertTrue(new File(projectRoot, AlignmentTask.GME_PLUGINCONFIGS).exists());
-        assertEquals(AlignmentTask.INJECT_GME_START_KOTLIN, TestUtils.getLine(projectRoot));
-        assertEquals(AlignmentTask.INJECT_GME_END_KOTLIN, FileUtils.getLastLine(new File(projectRoot, "build.gradle.kts")));
+        assertEquals(AlignmentTask.INJECT_GME_END_KOTLIN, FileUtils.getLastLine(buildFile));
+        List<String> lines = org.apache.commons.io.FileUtils.readLines(buildFile, Charset.defaultCharset());
+        assertEquals(1, lines.stream().filter(s -> s.contains("buildscript")).count());
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
             assertThat(am.getGroup()).isEqualTo("org.postgresql");

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleExistingManipulationProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleExistingManipulationProjectFunctionalTest.java
@@ -75,7 +75,7 @@ public class SimpleExistingManipulationProjectFunctionalTest extends AbstractWir
         final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName(), false);
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.INJECT_GME_START, TestUtils.getLine(projectRoot));
+        assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot));
         assertEquals(AlignmentTask.INJECT_GME_END, FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
@@ -114,7 +114,7 @@ public class SimpleExistingManipulationProjectFunctionalTest extends AbstractWir
         final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName(), false);
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.INJECT_GME_START, TestUtils.getLine(projectRoot));
+        assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot));
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
             assertThat(am.getGroup()).isEqualTo("org.acme.gradle");

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleProjectFunctionalTest.java
@@ -87,7 +87,7 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
         assertThat(new File(projectRoot, AlignmentTask.GME)).exists();
         assertThat(new File(projectRoot, AlignmentTask.GRADLE + File.separator + AlignmentTask.GME_REPOS)).exists();
         assertThat(new File(projectRoot, AlignmentTask.GME_PLUGINCONFIGS)).exists();
-        assertEquals(AlignmentTask.INJECT_GME_START, TestUtils.getLine(projectRoot));
+        assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot));
         assertEquals(AlignmentTask.INJECT_GME_END,
                 org.jboss.gm.common.utils.FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
 
@@ -161,7 +161,7 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
         assertThat(new File(projectRoot, AlignmentTask.GME)).exists();
         assertThat(new File(projectRoot, AlignmentTask.GRADLE + '/' + AlignmentTask.GME_REPOS)).exists();
         assertThat(new File(projectRoot, AlignmentTask.GME_PLUGINCONFIGS)).exists();
-        assertEquals(AlignmentTask.INJECT_GME_START, TestUtils.getLine(projectRoot));
+        assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot));
         assertEquals(AlignmentTask.INJECT_GME_END,
                 org.jboss.gm.common.utils.FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
 
@@ -188,7 +188,7 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
         List<String> lines = FileUtils.readLines(new File(projectRoot, Project.DEFAULT_BUILD_FILE), Charset.defaultCharset());
 
         assertThat(new File(projectRoot, AlignmentTask.GME)).exists();
-        assertEquals(AlignmentTask.INJECT_GME_START, org.jboss.gm.common.utils.FileUtils.getFirstLine(lines));
+        assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot));
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
             assertThat(am.getGroup()).isEqualTo("org.acme.gradle");
             assertThat(am.getName()).isEqualTo("root");
@@ -212,10 +212,10 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
         assertThat(alignmentModel).isNotNull().satisfies(am -> {
             assertThat(am.getGroup()).isEqualTo("org.acme.gradle");
             assertThat(am.getName()).isEqualTo("root");
-            assertThat(am.findCorrespondingChild("root"))
-                    .satisfies(root -> assertThat(root.getVersion()).isEqualTo("1.0.1.redhat-00003"));
+            assertThat(am.findCorrespondingChild("root")).satisfies(
+                    root -> assertThat(root.getVersion()).isEqualTo("1.0.1.redhat-00003"));
         });
-        assertEquals(AlignmentTask.INJECT_GME_START, org.jboss.gm.common.utils.FileUtils.getFirstLine(lines));
+        assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot));
 
         assertThat(lines).filteredOn(l -> l.startsWith(AlignmentTask.INJECT_GME_START)).hasSize(1);
     }
@@ -239,7 +239,7 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
         assertThat(new File(projectRoot, AlignmentTask.GME)).exists();
         assertThat(new File(projectRoot, AlignmentTask.GRADLE + '/' + AlignmentTask.GME_REPOS)).exists();
         assertThat(new File(projectRoot, AlignmentTask.GME_PLUGINCONFIGS)).exists();
-        assertEquals(AlignmentTask.INJECT_GME_START, TestUtils.getLine(projectRoot));
+        assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot));
         assertEquals(AlignmentTask.INJECT_GME_END,
                 org.jboss.gm.common.utils.FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
 

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleProjectWithSpringDMPluginFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/SimpleProjectWithSpringDMPluginFunctionalTest.java
@@ -60,7 +60,7 @@ public class SimpleProjectWithSpringDMPluginFunctionalTest extends AbstractWirem
         final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
-        assertEquals(AlignmentTask.INJECT_GME_START, TestUtils.getLine(projectRoot));
+        assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot));
         assertEquals(AlignmentTask.INJECT_GME_END, FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)));
 
         assertThat(alignmentModel).isNotNull().satisfies(am -> {

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/VersionConflictProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/VersionConflictProjectFunctionalTest.java
@@ -71,7 +71,7 @@ public class VersionConflictProjectFunctionalTest extends AbstractWiremockTest {
         final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName(), map);
 
         assertThat(new File(projectRoot, AlignmentTask.GME)).exists();
-        assertThat(TestUtils.getLine(projectRoot)).isEqualTo(AlignmentTask.INJECT_GME_START);
+        assertThat(TestUtils.getLine(projectRoot)).isEqualTo(AlignmentTask.INJECT_GME_START + " }");
         assertThat(FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)))
                 .isEqualTo(AlignmentTask.INJECT_GME_END);
 
@@ -123,7 +123,7 @@ public class VersionConflictProjectFunctionalTest extends AbstractWiremockTest {
         final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName(), map);
 
         assertThat(new File(projectRoot, AlignmentTask.GME)).exists();
-        assertThat(TestUtils.getLine(projectRoot)).isEqualTo(AlignmentTask.INJECT_GME_START);
+        assertThat(TestUtils.getLine(projectRoot)).isEqualTo(AlignmentTask.INJECT_GME_START + " }");
         assertThat(FileUtils.getLastLine(new File(projectRoot, Project.DEFAULT_BUILD_FILE)))
                 .isEqualTo(AlignmentTask.INJECT_GME_END);
 

--- a/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/WarFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/gm/analyzer/alignment/WarFunctionalTest.java
@@ -42,6 +42,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static junit.framework.TestCase.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class WarFunctionalTest extends AbstractWiremockTest {
@@ -117,7 +118,7 @@ public class WarFunctionalTest extends AbstractWiremockTest {
         assertThat(projectRoot.resolve(AlignmentTask.GME)).exists();
         assertThat(projectRoot.resolve(AlignmentTask.GRADLE).resolve(AlignmentTask.GME_REPOS)).exists();
         assertThat(projectRoot.resolve(AlignmentTask.GME_PLUGINCONFIGS)).exists();
-        assertThat(TestUtils.getLine(projectRoot.toFile())).isEqualTo(AlignmentTask.INJECT_GME_START);
+        assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot.toFile()));
         assertThat(FileUtils.getLastLine(projectRoot.resolve(Project.DEFAULT_BUILD_FILE).toFile()))
                 .isEqualTo(AlignmentTask.INJECT_GME_END);
         assertThat(systemOutRule.getLog()).contains("Passing 1 GAVs into the REST client api [" + GAV + "]");

--- a/analyzer/src/functTest/resources/pgjdbc/build.gradle.kts
+++ b/analyzer/src/functTest/resources/pgjdbc/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
     id("org.jboss.gm.analyzer")
 
 }
+buildscript { // Empty block
+}
 
 val String.v: String get() = rootProject.extra["$this.version"] as String
 val buildVersion = "pgjdbc".v

--- a/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/io/LockFileIO.java
+++ b/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/io/LockFileIO.java
@@ -74,9 +74,9 @@ public class LockFileIO {
         }
 
         try (Stream<Path> stream = Files.find(locksRoot.toPath(), 1,
-            (filePath, fileAttr) -> fileAttr.isRegularFile() && filePath.getFileName().toString().endsWith(
-                (LOCKFILE_EXTENSION)))) {
-                    return stream.map(Path::toFile).collect(Collectors.toList());
+                (filePath, fileAttr) -> fileAttr.isRegularFile() && filePath.getFileName().toString().endsWith(
+                        (LOCKFILE_EXTENSION)))) {
+            return stream.map(Path::toFile).collect(Collectors.toList());
         }
     }
 

--- a/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/io/SettingsFileIO.java
+++ b/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/io/SettingsFileIO.java
@@ -68,7 +68,7 @@ public class SettingsFileIO {
                     try (BufferedWriter writer = new BufferedWriter(new FileWriter(settingsGradle, true))) {
                         // Ensure the marker is on a line by itself.
                         writer.newLine();
-                        writer.write("rootProject.name='" + result + "'");
+                        writer.write("rootProject.name=\"" + result + "\"");
                         writer.newLine();
                         writer.flush();
                     }

--- a/cli/src/test/java/org/jboss/gm/cli/SemanticPluginTest.java
+++ b/cli/src/test/java/org/jboss/gm/cli/SemanticPluginTest.java
@@ -49,10 +49,10 @@ public class SemanticPluginTest {
         final File folder = tempDir.newFolder();
 
         try (Git ignored = Git.cloneRepository()
-            .setURI("https://github.com/linkedin/cruise-control.git")
-            .setDirectory(folder)
-            .setBranch("refs/tags/2.5.73")
-            .call()) {
+                .setURI("https://github.com/linkedin/cruise-control.git")
+                .setDirectory(folder)
+                .setBranch("refs/tags/2.5.73")
+                .call()) {
             System.out.println("Cloned CruiseControl to " + folder);
         }
 


### PR DESCRIPTION
… quotes. Improved buildscript injection