### PR TITLE
Fix Dokka version detection

### DIFF
--- a/common/src/main/java/org/jboss/gm/common/utils/PluginUtils.java
+++ b/common/src/main/java/org/jboss/gm/common/utils/PluginUtils.java
@@ -71,12 +71,14 @@ public class PluginUtils {
             } catch (InvalidVersionSpecificationException e) {
                 throw new ManipulationException("Unable to parse version: {}", version);
             }
-            if (MINIMUM.version.compareTo(v) >= 0) {
-                return MINIMUM;
-            } else if (v.compareTo(POST_ONE.version) >= 0) {
+            if (v.compareTo(POST_ONE.version) >= 0) {
                 return POST_ONE;
+            } else if (v.compareTo(TEN.version) >= 0) {
+                return TEN;
+            } else if (MINIMUM.version.compareTo(v) >= 0) {
+                return MINIMUM;
             }
-            return TEN;
+            return NONE;
         }
     }
 

--- a/common/src/test/java/org/jboss/gm/common/utils/PluginUtilsTest.java
+++ b/common/src/test/java/org/jboss/gm/common/utils/PluginUtilsTest.java
@@ -633,7 +633,8 @@ public class PluginUtilsTest {
 
     @Test
     public void testParseDokkaVersion() throws ManipulationException {
-        assertEquals(PluginUtils.DokkaVersion.parseVersion("0.9.17"), PluginUtils.DokkaVersion.MINIMUM);
+        assertEquals(PluginUtils.DokkaVersion.parseVersion("0.9.17"), PluginUtils.DokkaVersion.NONE);
+        assertEquals(PluginUtils.DokkaVersion.parseVersion("0.9.18"), PluginUtils.DokkaVersion.MINIMUM);
         assertEquals(PluginUtils.DokkaVersion.parseVersion("0.10.1"), PluginUtils.DokkaVersion.TEN);
         assertEquals(PluginUtils.DokkaVersion.parseVersion("1.6.0"), PluginUtils.DokkaVersion.POST_ONE);
     }


### PR DESCRIPTION
The noJdkLink attribute was added in 0.9.18, however this will always attempt to add this attribute even when dokka is an older version, as the existing code will never return NONE, only MINIMUM.