### PR TITLE
Update to PME 4.16. Library updates and Jackson handling

### DIFF
--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -26,9 +26,29 @@ dependencies {
     shadow(localGroovy())
     shadow(gradleApi())
 
-    implementation("org.commonjava.maven.ext:pom-manipulation-core:${project.extra.get("pmeVersion")}")
-    implementation("org.commonjava.maven.ext:pom-manipulation-io:${project.extra.get("pmeVersion")}")
-    implementation("org.commonjava.maven.ext:pom-manipulation-common:${project.extra.get("pmeVersion")}")
+    implementation("com.fasterxml.jackson.core:jackson-databind:${project.extra.get("jacksonVersion")}")
+    implementation("com.fasterxml.jackson.core:jackson-annotations:${project.extra.get("jacksonVersion")}")
+    implementation("com.fasterxml.jackson.core:jackson-core:${project.extra.get("jacksonVersion")}")
+
+    implementation("org.commonjava.maven.ext:pom-manipulation-core:${project.extra.get("pmeVersion")}") {
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-core")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-annotations")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-databind")
+        }
+
+    implementation("org.commonjava.maven.ext:pom-manipulation-io:${project.extra.get("pmeVersion")}") {
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-core")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-annotations")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-databind")
+        }
+
+    implementation("org.commonjava.maven.ext:pom-manipulation-common:${project.extra.get("pmeVersion")}") {
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-core")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-annotations")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-databind")
+        }
+
+
     implementation("org.commonjava.maven.atlas:atlas-identities:${project.extra.get("atlasVersion")}")
 
     runtimeOnly("org.apache.maven:maven-artifact:${project.extra.get("mavenVersion")}")

--- a/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/io/RepositoryExporter.java
+++ b/analyzer/src/main/java/org/jboss/gm/analyzer/alignment/io/RepositoryExporter.java
@@ -14,6 +14,7 @@ import org.apache.maven.settings.Repository;
 import org.apache.maven.settings.RepositoryPolicy;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.building.DefaultSettingsBuilder;
+import org.apache.maven.settings.building.DefaultSettingsBuilderFactory;
 import org.commonjava.maven.ext.common.ManipulationException;
 import org.commonjava.maven.ext.common.ManipulationUncheckedException;
 import org.commonjava.maven.ext.io.SettingsIO;
@@ -62,7 +63,7 @@ public final class RepositoryExporter {
         RepositoryExporter repositoryExporter = new RepositoryExporter();
         processRepositories(repositoryExporter, repositories);
 
-        SettingsIO settingsWriter = new SettingsIO(new DefaultSettingsBuilder());
+        SettingsIO settingsWriter = new SettingsIO(new DefaultSettingsBuilderFactory().newInstance());
         logger.debug("Writing repository settings into {}", settingsFile.getAbsolutePath());
         try {
             settingsWriter.write(repositoryExporter.mavenSettings, settingsFile);

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -202,17 +202,21 @@ subprojects {
     extra["commonsBeanVersion"] = "1.9.4"
     extra["commonsVersion"] = "2.6"
     extra["gradleVersion"] = "5.6.4"
-    extra["groovyVersion"] = "3.0.11"
+    extra["groovyVersion"] = "3.0.17"
     extra["ivyVersion"] = "2.5.0"
-    extra["jacksonVersion"] = "2.11.2"
+    // Note - this *downgrades* Jackson from what is used in PME. This is due to
+    // https://github.com/gradle/gradle/issues/24390
+    // https://github.com/FasterXML/jackson-core/issues/955
+    // This exclusion isn't required on 7.6.1 and above.
+    extra["jacksonVersion"] = "2.14.3"
     extra["jgitVersion"] = "6.3.0.202209071007-r"
     extra["junitVersion"] = "4.13.1"
     extra["logbackVersion"] = "1.2.9"
-    extra["mavenVersion"] = "3.5.0"
+    extra["mavenVersion"] = "3.6.3"
     extra["opentelemetryVersion"] = "1.2.0"
     extra["ownerVersion"] = "1.0.12"
     extra["pmeVersion"] = "4.16"
-    extra["slf4jVersion"] = "1.7.30"
+    extra["slf4jVersion"] = "1.7.36"
     extra["systemRulesVersion"] = "1.19.0"
 
     if (org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("5.4")) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -211,7 +211,7 @@ subprojects {
     extra["mavenVersion"] = "3.5.0"
     extra["opentelemetryVersion"] = "1.2.0"
     extra["ownerVersion"] = "1.0.12"
-    extra["pmeVersion"] = "4.14"
+    extra["pmeVersion"] = "4.16"
     extra["slf4jVersion"] = "1.7.30"
     extra["systemRulesVersion"] = "1.19.0"
 

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -12,9 +12,27 @@ dependencies {
     implementation("org.gradle:gradle-tooling-api:${project.extra.get("gradleVersion")}")
     implementation("info.picocli:picocli:4.0.4")
 
-    implementation("org.commonjava.maven.ext:pom-manipulation-core:${project.extra.get("pmeVersion")}")
-    implementation("org.commonjava.maven.ext:pom-manipulation-io:${project.extra.get("pmeVersion")}")
-    implementation("org.commonjava.maven.ext:pom-manipulation-common:${project.extra.get("pmeVersion")}")
+    implementation("com.fasterxml.jackson.core:jackson-databind:${project.extra.get("jacksonVersion")}")
+    implementation("com.fasterxml.jackson.core:jackson-annotations:${project.extra.get("jacksonVersion")}")
+    implementation("com.fasterxml.jackson.core:jackson-core:${project.extra.get("jacksonVersion")}")
+
+    implementation("org.commonjava.maven.ext:pom-manipulation-core:${project.extra.get("pmeVersion")}") {
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-core")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-annotations")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-databind")
+        }
+
+    implementation("org.commonjava.maven.ext:pom-manipulation-common:${project.extra.get("pmeVersion")}") {
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-core")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-annotations")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-databind")
+        }
+
+    implementation("org.commonjava.maven.ext:pom-manipulation-io:${project.extra.get("pmeVersion")}") {
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-core")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-annotations")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-databind")
+        }
 
     implementation("org.slf4j:slf4j-api:${project.extra.get("slf4jVersion")}")
     implementation("org.codehaus.groovy:groovy:${project.extra.get("groovyVersion")}")

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -12,16 +12,31 @@ dependencies {
 
     implementation("org.commonjava.maven.atlas:atlas-identities:${project.extra.get("atlasVersion")}")
 
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.9.8")
+    implementation("com.fasterxml.jackson.core:jackson-databind:${project.extra.get("jacksonVersion")}")
     implementation("com.fasterxml.jackson.core:jackson-annotations:${project.extra.get("jacksonVersion")}")
     implementation("com.fasterxml.jackson.core:jackson-core:${project.extra.get("jacksonVersion")}")
 
     implementation("org.slf4j:slf4j-api:${project.extra.get("slf4jVersion")}")
     implementation("org.codehaus.groovy:groovy:${project.extra.get("groovyVersion")}")
 
-    implementation("org.commonjava.maven.ext:pom-manipulation-common:${project.extra.get("pmeVersion")}")
-    implementation("org.commonjava.maven.ext:pom-manipulation-core:${project.extra.get("pmeVersion")}")
-    implementation("org.commonjava.maven.ext:pom-manipulation-io:${project.extra.get("pmeVersion")}")
+    implementation("org.commonjava.maven.ext:pom-manipulation-common:${project.extra.get("pmeVersion")}") {
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-core")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-annotations")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-databind")
+        }
+
+    implementation("org.commonjava.maven.ext:pom-manipulation-core:${project.extra.get("pmeVersion")}") {
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-core")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-annotations")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-databind")
+        }
+
+    implementation("org.commonjava.maven.ext:pom-manipulation-io:${project.extra.get("pmeVersion")}") {
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-core")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-annotations")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-databind")
+        }
+
 
     runtimeOnly("org.apache.maven:maven-core:${project.extra.get("mavenVersion")}")
     runtimeOnly("org.apache.maven:maven-model:${project.extra.get("mavenVersion")}")
@@ -30,7 +45,7 @@ dependencies {
     implementation("com.redhat.resilience.otel:opentelemetry-ext-cli-java:${project.extra.get("opentelemetryVersion")}")
 
     // This is to prevent compilation errors in conjunction with Lombok due to use of PME code.
-    compileOnly("org.apache.maven:maven-compat:3.5.0")
+    compileOnly("org.apache.maven:maven-compat:${project.extra.get("mavenVersion")}")
 
     testFixturesCompile("org.codehaus.plexus:plexus-archiver:4.2.3")
     testFixturesCompile("org.assertj:assertj-core:${project.extra.get("assertjVersion")}")

--- a/manipulation/build.gradle.kts
+++ b/manipulation/build.gradle.kts
@@ -30,7 +30,11 @@ dependencies {
     implementation("commons-lang:commons-lang:${project.extra.get("commonsVersion")}")
     implementation("commons-beanutils:commons-beanutils:${project.extra.get("commonsBeanVersion")}")
 
-    implementation("org.commonjava.maven.ext:pom-manipulation-common:${project.extra.get("pmeVersion")}")
+    implementation("org.commonjava.maven.ext:pom-manipulation-common:${project.extra.get("pmeVersion")}") {
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-core")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-annotations")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-databind")
+        }
     implementation("org.commonjava.maven.atlas:atlas-identities:${project.extra.get("atlasVersion")}")
 
     // Owner: Need Java8 dependency which pulls in owner itself.

--- a/manipulation/src/functTest/java/org/jboss/gm/manipulation/KafkaProjectWithMavenPluginFunctionalTest.java
+++ b/manipulation/src/functTest/java/org/jboss/gm/manipulation/KafkaProjectWithMavenPluginFunctionalTest.java
@@ -89,12 +89,9 @@ public class KafkaProjectWithMavenPluginFunctionalTest {
         final BuildResult buildResult = TestUtils.createGradleRunner()
                 .withProjectDir(kafka)
                 .withGradleVersion("7.2")
-                //.withDebug(true)
                 .withArguments("--info", "-PskipSigning=true", "-PscalaVersion=2.12", "-PscalaOptimizerMode=inline"
                         + "-scala",
                         "assemble", "releaseRedHatZip", "uploadArchives", "-x", "test")
-                .withPluginClasspath()
-                .forwardOutput()
                 .build();
         assertThat(buildResult.task(":assemble").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
 


### PR DESCRIPTION
This PR updates various library versions to match those from PME 4.16. It also updates PME itself but has to force exclude the Jackson transitive dependency. The problem is the latest Jackson update is a multi-release jar. Only very recent Gradle versions are compatible with such jars. 

Therefore rather  then re-releasing PME downgrading Jackson back from 2.15x to 2.14x it seemed simpler to handle it solely within GME. 

