### PR TITLE
Remove coverage from snapshot builds

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -113,8 +113,3 @@ jobs:
     - uses: gradle/gradle-build-action@v2
       with:
         arguments: clean build publish AggregateJacocoReport
-    - name: Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        files: ./build/reports/jacoco/aggregate/jacocoTestReport.xml
-        verbose: true


### PR DESCRIPTION
We really only need coverage verification on the main PR request builds.