### PR TITLE
Build file improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,17 @@ You may run only certain tests (e.g., the tests in a class named `TestClass`) us
 gradle test --tests TestClass
 ```
 
+
+### CI
+
+The CI runs over a multitude of versions using both JDK11 and JDK17. This is controlled by two workflows in the `.github/workflows/gradle.yml` file.
+
+Note that in order to handle using earlier versions of Gradle without making the build file incomprehensible we use `fix-build.sh`. This is run for all versions <8.3 (i.e. the first workflow). Currently this handles the following:
+
+* Gradle 4.10/5.0  : Modifies for use of archiveClassifier
+* Gradle 4.10      : Modifies for use of named tasks
+* Gradle 4/5/6/7.0 : Modifies for use of non-qualified GradleVersion API.
+
 ### Releasing
 
 The project has been configured to release both plugins to the Gradle Portal and to release to Maven Central.
@@ -204,7 +215,7 @@ The command will both publish the plugin to the Gradle Plugin Portal and to Mave
 Note: It is **very** important to execute this exact command when releasing. Adding other tasks (e.g., `clean`) can cause the release to fail, or even worse leave the release in an inconsistent state. If `clean` is needed, run it separately before the main command. If a release needs to be rolled back the following must be checked and cleaned up:
 
 * Gradle Plugins Portal (https://plugins.gradle.org/)
-* Sonatype Staging (https://oss.sonatype.org/#stagingRepositories)
+* Sonatype Deployments (https://central.sonatype.com/publishing/deployments)
 * Local and remote tags
 * Local and remote GIT commits for release
 
@@ -227,6 +238,7 @@ To change the version that will be deployed just add `-Pversion=whatever`.
 
 The artifacts can be pushed to the Sonatype snapshot repository (e.g., https://oss.sonatype.org/content/repositories/snapshots/org/jboss/gm/analyzer/analyzer/) with the following command:
 
-    gradle publishAllPublicationsToSonatype-nexus-snapshotsRepository
+    gradle publishAggregationToCentralPortalSnapshots
 
+Note that `publishToCentral` achieves the same for snapshot versions.
 Note that your username/password in `$HOME/.m2/settings.xml` for Sonatype must be setup.

--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -8,7 +8,7 @@ group = "org.jboss.gm"
 // According to https://plugins.gradle.org/docs/publish-plugin the simplifications in plugin publishing requires
 // Gradle 7.6 or later. Therefore use reflection here.
 gradlePlugin {
-    if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("7.6")) {
+    if (GradleVersion.current() >= GradleVersion.version("7.6")) {
         var pluginPublishMethod = GradlePluginDevelopmentExtension::class.memberFunctions.find{it.name == "getWebsite"}
         @Suppress("UNCHECKED_CAST")
         var wProperty: Property<String> = pluginPublishMethod?.call(this) as Property<String>
@@ -26,7 +26,7 @@ gradlePlugin {
             implementationClass = "org.jboss.gm.analyzer.alignment.AlignmentPlugin"
             displayName = "GME Manipulation Plugin"
 
-            if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("7.6")) {
+            if (GradleVersion.current() >= GradleVersion.version("7.6")) {
                 var getTagsMethod = PluginDeclaration::class.memberFunctions.find { it.name == "getTags" }
                 @Suppress("UNCHECKED_CAST")
                 var sProperty = getTagsMethod?.call(this) as SetProperty<String>
@@ -123,7 +123,7 @@ idea.module {
     // testSources / testResources only available from 7.4 and greater so can't just do:
     // testSources.from(sourceSets["functionalTest"].java.srcDirs)
     // Not bothering to handle other versions as we're developing on later Gradle now.
-    if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("7.4")) {
+    if (GradleVersion.current() >= GradleVersion.version("7.4")) {
         var rTestSources = IdeaModule::class.memberFunctions.find{it.name == "getTestSources"}
         var fileCollection = rTestSources?.call(this) as ConfigurableFileCollection
         fileCollection.from(sourceSets["functionalTest"].java.srcDirs)

--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -10,9 +10,11 @@ group = "org.jboss.gm"
 gradlePlugin {
     if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("7.6")) {
         var pluginPublishMethod = GradlePluginDevelopmentExtension::class.memberFunctions.find{it.name == "getWebsite"}
-        var wProperty = pluginPublishMethod?.call(this) as Property<String>
+        @Suppress("UNCHECKED_CAST")
+        var wProperty: Property<String> = pluginPublishMethod?.call(this) as Property<String>
         wProperty.set("https://project-ncl.github.io/gradle-manipulator")
         pluginPublishMethod = GradlePluginDevelopmentExtension::class.memberFunctions.find{it.name == "getVcsUrl"}
+        @Suppress("UNCHECKED_CAST")
         wProperty = pluginPublishMethod?.call(this) as Property<String>
         wProperty.set("https://github.com/project-ncl/gradle-manipulator.git")
     }
@@ -25,8 +27,8 @@ gradlePlugin {
             displayName = "GME Manipulation Plugin"
 
             if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("7.6")) {
-                var getTagsMethod =
-                    PluginDeclaration::class.memberFunctions.find { it.name == "getTags" }
+                var getTagsMethod = PluginDeclaration::class.memberFunctions.find { it.name == "getTags" }
+                @Suppress("UNCHECKED_CAST")
                 var sProperty = getTagsMethod?.call(this) as SetProperty<String>
                 sProperty.set(listOf("versions", "alignment"))
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,15 +21,15 @@ plugins {
     idea
 
     // Note spotless is only active for Gradle >= 6.1.1. Using 6.8.3 for the extra fixes.
-    if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("6.8.3")) {
+    if (GradleVersion.current() >= GradleVersion.version("6.8.3")) {
         id("com.diffplug.spotless") version "7.2.1"
-    } else if (org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("5.4")) {
+    } else if (GradleVersion.current() < GradleVersion.version("5.4")) {
         id("com.diffplug.gradle.spotless") version "4.5.1"
     } else {
         id("com.diffplug.spotless") version "5.14.2"
     }
 
-    if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("6.0")) {
+    if (GradleVersion.current() >= GradleVersion.version("6.0")) {
         id("com.gradle.plugin-publish") version "1.3.1" apply false
     } else {
         id("com.gradle.plugin-publish") version "0.21.0"
@@ -42,28 +42,28 @@ plugins {
     id("io.github.rmanibus.maven-settings") version "0.8" apply false
 
     when {
-        org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("5.0") -> {
+        GradleVersion.current() < GradleVersion.version("5.0") -> {
             id("com.adarshr.test-logger") version "1.7.1"
             // XXX: Versions 4.x > 4.0.1 suffer from <https://github.com/johnrengelman/shadow/issues/425>
             id("com.github.johnrengelman.shadow") version "4.0.1" apply false
         }
-        org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("6.0") -> {
+        GradleVersion.current() < GradleVersion.version("6.0") -> {
             id("com.adarshr.test-logger") version "2.1.1"
             id("com.github.johnrengelman.shadow") version "5.2.0" apply false
         }
-        org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("7.0") -> {
+        GradleVersion.current() < GradleVersion.version("7.0") -> {
             id("com.adarshr.test-logger") version "2.1.1"
             id("com.github.johnrengelman.shadow") version "6.1.0" apply false
         }
-        org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("8.0") -> {
+        GradleVersion.current() < GradleVersion.version("8.0") -> {
             id("com.adarshr.test-logger") version "3.2.0"
             id("com.github.johnrengelman.shadow") version "7.1.2" apply false
         }
-        org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("8.3") -> {
+        GradleVersion.current() < GradleVersion.version("8.3") -> {
             id("com.adarshr.test-logger") version "3.2.0"
             id("com.github.johnrengelman.shadow") version "8.1.1" apply false
         }
-        org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("9.0.0") -> {
+        GradleVersion.current() >= GradleVersion.version("9.0.0") -> {
             id("com.adarshr.test-logger") version "4.0.0"
             id("com.gradleup.shadow") version "9.0.2" apply false
         }
@@ -79,16 +79,16 @@ plugins {
     }
 
     when {
-        org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("5.0") -> {
+        GradleVersion.current() < GradleVersion.version("5.0") -> {
             id("io.freefair.lombok") version "2.9.5" apply false
         }
-        org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("5.2") -> {
+        GradleVersion.current() < GradleVersion.version("5.2") -> {
             id("io.freefair.lombok") version "3.0.0" apply false
         }
-        org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("6.0") -> {
+        GradleVersion.current() < GradleVersion.version("6.0") -> {
             id("io.freefair.lombok") version "4.1.6" apply false
         }
-        org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("8.0") -> {
+        GradleVersion.current() < GradleVersion.version("8.0") -> {
             id("io.freefair.lombok") version "5.3.3.3" apply false
         }
         else -> {
@@ -99,27 +99,27 @@ plugins {
     // Not compatible with Gradle 9 yet.
     // https://github.com/kordamp/kordamp-gradle-plugins/issues/540
     // See also below as a fake task for AggregateJacocoReport has been created for Gradle 9
-    if (org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("9.0.0")) {
-        if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("8.0")) {
+    if (GradleVersion.current() < GradleVersion.version("9.0.0")) {
+        if (GradleVersion.current() >= GradleVersion.version("8.0")) {
             id("org.kordamp.gradle.jacoco") version "0.54.0"
-        } else if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("7.0")) {
+        } else if (GradleVersion.current() >= GradleVersion.version("7.0")) {
             id("org.kordamp.gradle.jacoco") version "0.47.0"
-        } else if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("5.3")) {
+        } else if (GradleVersion.current() >= GradleVersion.version("5.3")) {
             id("org.kordamp.gradle.jacoco") version "0.46.0"
         }
     }
 }
 
 // XXX: Jacoco plugin only supports Gradle >= 5.3 ; create empty task on those Gradle versions so that build does not fail
-if (org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("5.3")
-    || org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("9.0.0")
+if (GradleVersion.current() < GradleVersion.version("5.3")
+    || GradleVersion.current() >= GradleVersion.version("9.0.0")
     ) {
     tasks.register("AggregateJacocoReport")
 }
 
 if (!JavaVersion.current().isJava11Compatible) {
     throw GradleException("This build must be run with at least Java 11")
-} else if (org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("4.10")) {
+} else if (GradleVersion.current() < GradleVersion.version("4.10")) {
     throw GradleException("This build must be run with at least Gradle 4.10")
 }
 
@@ -246,7 +246,7 @@ subprojects {
     extra["slf4jVersion"] = "2.0.17"
     extra["systemStubsVersion"] = "2.1.8"
 
-    if (org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("5.4")) {
+    if (GradleVersion.current() < GradleVersion.version("5.4")) {
         apply(plugin = "com.diffplug.gradle.spotless")
     } else {
         apply(plugin = "com.diffplug.spotless")
@@ -259,8 +259,8 @@ subprojects {
     extra["lombokVersion"] = extensions.findByType(LombokExtension::class)?.version
 
     // XXX: Lombok plugin 3.x < 3.6.1 suffers from <https://github.com/freefair/gradle-plugins/issues/31>
-    if (org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("5.0")
-        || org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("5.2")) {
+    if (GradleVersion.current() < GradleVersion.version("5.0")
+        || GradleVersion.current() >= GradleVersion.version("5.2")) {
         // Don't generate lombok.config files ( https://docs.freefair.io/gradle-plugins/3.6.6/reference/#_lombok_config_handling )
         tasks.findByName("generateLombokConfig")?.enabled = false
     }
@@ -361,7 +361,7 @@ subprojects {
          * Another great source of information is the configuration of the shadow plugin itself:
          * https://github.com/johnrengelman/shadow/blob/main/build.gradle
          */
-        if (org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("8.3")) {
+        if (GradleVersion.current() < GradleVersion.version("8.3")) {
             apply(plugin = "com.github.johnrengelman.shadow")
         } else {
             apply(plugin = "com.gradleup.shadow")
@@ -379,7 +379,7 @@ subprojects {
             exclude("analyzer-init.gradle")
 
             // XXX: Skip minimization for Gradle 4.10 (ShadowJar 4.0.1) due to missing classes
-            if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("5.0")) {
+            if (GradleVersion.current() >= GradleVersion.version("5.0")) {
                 // Minimise the resulting uber-jars to ensure we don't have massive jars
                 minimize {
                     // Sometimes minimisation takes away too much ... ensure we keep these.
@@ -416,7 +416,7 @@ subprojects {
 
         // configure publishing of the shadowJar
         var publicationComponent = "shadow"
-        if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("8.3")) {
+        if (GradleVersion.current() >= GradleVersion.version("8.3")) {
             if (project.name == "cli") {
                 configure<PublishingExtension> {
                     publications {
@@ -510,7 +510,7 @@ subprojects {
             // Can't use asFile (from https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.resources/-text-resource/index.html )
             // as that creates and writes the File immediately ... which is then deleted
             // by Gradle clean. configProperties was only available from Spotless 7.0 (which requires Gradle >= 6.1.1)
-            if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("${project.extra.get("gradleReleaseVersion")}")) {
+            if (GradleVersion.current() >= GradleVersion.version("${project.extra.get("gradleReleaseVersion")}")) {
                 removeUnusedImports()
                 importOrder(resources.text.fromArchiveEntry(spotlessConfig, "java-import-order.txt").asString())
                 val formatter = resources.text.fromArchiveEntry(spotlessConfig, "java-formatter.xml").asString()
@@ -527,7 +527,7 @@ subprojects {
     }
 
     tasks.withType<JavaCompile>().configureEach {
-        if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("${project.extra.get("gradleReleaseVersion")}")) {
+        if (GradleVersion.current() >= GradleVersion.version("${project.extra.get("gradleReleaseVersion")}")) {
             dependsOn("spotlessApply")
         }
     }
@@ -626,7 +626,7 @@ fun loadSettings(extension: MavenSettingsPluginExtension, repository: String) {
 
 
 val isReleaseBuild = ("true" == gradle.startParameter.projectProperties.getOrDefault("release", ""))
-if (isReleaseBuild && org.gradle.util.GradleVersion.current().version != "${project.extra.get("gradleReleaseVersion")}") {
+if (isReleaseBuild && GradleVersion.current().version != "${project.extra.get("gradleReleaseVersion")}") {
     throw GradleException("Gradle ${project.extra.get("gradleReleaseVersion")} is required to release this project")
 } else if (isReleaseBuild) {
     logger.lifecycle ("Running as release build")
@@ -635,8 +635,8 @@ if (System.getProperty("release") != null) {
     throw GradleException("Pass release=true as a -P parameter")
 }
 
-if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("8.3") &&
-    org.gradle.util.GradleVersion.current() < org.gradle.util.GradleVersion.version("9.0.0")) {
+if (GradleVersion.current() >= GradleVersion.version("8.3") &&
+    GradleVersion.current() < GradleVersion.version("9.0.0")) {
     // LinkageError: loader constraint violation from GMEFunctionalTest otherwise
     if (System.getProperty("gmeFunctionalTest") == null) {
         val mavenExtension =

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -69,7 +69,7 @@ tasks.named("test") {
     dependsOn("shadowJar")
 }
 
-if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("5.0")) {
+if (GradleVersion.current() >= GradleVersion.version("5.0")) {
     tasks.named("generateMetadataFileForShadowPublication") {
         dependsOn("jar")
     }

--- a/gradle/fix-build.sh
+++ b/gradle/fix-build.sh
@@ -30,8 +30,19 @@ esac
 case "${VERSION}" in
     4.10*)
         echo "Modifying build for named tasks"
-        find ../ -name 'build.gradle.kts' ! -path '*/functTest/*' -print0 | xargs -0 -t sed -i \
+        find ../ -name 'build.gradle.kts' ! -path '*/functTest/*' -print0 | xargs -0 sed -i \
              -e 's|tasks.named[(]|tasks.getByName(|g;'
+        ;;
+    *)
+        echo "Not modifying build"
+        ;;
+esac
+
+case "${VERSION}" in
+    4.10*|5.*|6.*|7.0*)
+        echo "Modifying build for GradleVersion"
+        find ../ -name 'build.gradle.kts' -print0 | xargs -0 sed -i \
+             -e 's|GradleVersion|org.gradle.util.GradleVersion|g;'
         ;;
     *)
         echo "Not modifying build"

--- a/manipulation/build.gradle.kts
+++ b/manipulation/build.gradle.kts
@@ -8,7 +8,7 @@ group = "org.jboss.gm"
 gradlePlugin {
     // According to https://plugins.gradle.org/docs/publish-plugin the simplifications in plugin publishing requires
     // Gradle 7.6 or later. Therefore use reflection here.
-    if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("7.6")) {
+    if (GradleVersion.current() >= GradleVersion.version("7.6")) {
         var pluginPublishMethod = GradlePluginDevelopmentExtension::class.memberFunctions.find{it.name == "getWebsite"}
         @Suppress("UNCHECKED_CAST")
         var wProperty = pluginPublishMethod?.call(this) as Property<String>
@@ -26,7 +26,7 @@ gradlePlugin {
             implementationClass = "org.jboss.gm.manipulation.ManipulationPlugin"
             displayName = "GME Manipulation Plugin"
 
-            if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("7.6")) {
+            if (GradleVersion.current() >= GradleVersion.version("7.6")) {
                 var getTagsMethod = PluginDeclaration::class.memberFunctions.find { it.name == "getTags" }
                 @Suppress("UNCHECKED_CAST")
                 var sProperty = getTagsMethod?.call(this) as SetProperty<String>
@@ -74,7 +74,7 @@ dependencies {
     testImplementation(gradleTestKit())
 }
 
-if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("9.0.0")) {
+if (GradleVersion.current() >= GradleVersion.version("9.0.0")) {
     // Include a fake Upload purely for compilation purposes.
     sourceSets.getByName ("main") {
         java.srcDir("src/gradle9/java")
@@ -104,7 +104,7 @@ idea.module {
     // testSources / testResources only available from 7.4 and greater so can't just do:
     // testSources.from(sourceSets["functionalTest"].java.srcDirs).
     // Not bothering to handle other versions as we're developing on later Gradle now.
-    if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("7.4")) {
+    if (GradleVersion.current() >= GradleVersion.version("7.4")) {
         var rTestSources = IdeaModule::class.memberFunctions.find{it.name == "getTestSources"}
         var fileCollection = rTestSources?.call(this) as ConfigurableFileCollection
         fileCollection.from(sourceSets["functionalTest"].java.srcDirs)

--- a/manipulation/build.gradle.kts
+++ b/manipulation/build.gradle.kts
@@ -10,9 +10,11 @@ gradlePlugin {
     // Gradle 7.6 or later. Therefore use reflection here.
     if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("7.6")) {
         var pluginPublishMethod = GradlePluginDevelopmentExtension::class.memberFunctions.find{it.name == "getWebsite"}
+        @Suppress("UNCHECKED_CAST")
         var wProperty = pluginPublishMethod?.call(this) as Property<String>
         wProperty.set("https://project-ncl.github.io/gradle-manipulator")
         pluginPublishMethod = GradlePluginDevelopmentExtension::class.memberFunctions.find{it.name == "getVcsUrl"}
+        @Suppress("UNCHECKED_CAST")
         wProperty = pluginPublishMethod?.call(this) as Property<String>
         wProperty.set("https://github.com/project-ncl/gradle-manipulator.git")
     }
@@ -25,8 +27,8 @@ gradlePlugin {
             displayName = "GME Manipulation Plugin"
 
             if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("7.6")) {
-                var getTagsMethod =
-                    PluginDeclaration::class.memberFunctions.find { it.name == "getTags" }
+                var getTagsMethod = PluginDeclaration::class.memberFunctions.find { it.name == "getTags" }
+                @Suppress("UNCHECKED_CAST")
                 var sProperty = getTagsMethod?.call(this) as SetProperty<String>
                 sProperty.set(listOf("versions", "manipulation"))
             }


### PR DESCRIPTION
* Suppress cast warnings as we know the API returns those types
* Remove the redundant qualifier for `org.gradle.util.GradleVersion` but use `gradle/fix-build.sh` to patch it back in for Gradle < 7.1

Also improved the documentation to mention use of `fix-build.sh`.