### PR TITLE
NCLSUP-1402 Fix scanning for alignment with non-published modules

### DIFF
--- a/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/GrpcLikeLayoutFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/GrpcLikeLayoutFunctionalTest.java
@@ -84,7 +84,10 @@ public class GrpcLikeLayoutFunctionalTest extends AbstractWiremockTest {
         assumeTrue(GradleVersion.current().compareTo(GradleVersion.version("7.0")) < 0);
 
         final File projectRoot = tempDir.newFolder("grpc-like-layout");
-        final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
+        final TestManipulationModel alignmentModel = TestUtils.align(
+                projectRoot,
+                projectRoot.getName(),
+                Collections.singletonMap("scanProjectsWithNoPublications", "true"));
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
         assertEquals(AlignmentTask.INJECT_GME_START, TestUtils.getLine(projectRoot));

--- a/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/GrpcLikeLayoutWithPartialGroupFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/GrpcLikeLayoutWithPartialGroupFunctionalTest.java
@@ -15,7 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.commonjava.atlas.maven.ident.ref.ProjectVersionRef;
 import org.gradle.api.Project;
@@ -77,10 +77,12 @@ public class GrpcLikeLayoutWithPartialGroupFunctionalTest
         assumeTrue(GradleVersion.current().compareTo(GradleVersion.version("9.0.0")) < 0);
 
         final File projectRoot = tempDir.newFolder("grpc-like-layout-with-partial-group");
-        final Map<String, String> props = Collections.singletonMap(
+        Map<String, String> alignProps = new HashMap<>();
+        alignProps.put("scanProjectsWithNoPublications", "true");
+        alignProps.put(
                 "dependencyOverride.io.netty:*@*",
                 "4.1.42.Final-redhat-00001");
-        final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName(), props);
+        final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName(), alignProps);
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
         assertEquals(AlignmentTask.INJECT_GME_START, TestUtils.getLine(projectRoot));

--- a/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/InvalidProjectPassFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/InvalidProjectPassFunctionalTest.java
@@ -12,9 +12,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
+import java.util.Collections;
 import org.commonjava.atlas.maven.ident.ref.ProjectVersionRef;
 import org.jboss.byteman.contrib.bmunit.BMRule;
-import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.jboss.pnc.gradlemanipulator.analyzer.alignment.TestUtils.TestManipulationModel;
 import org.jboss.pnc.gradlemanipulator.common.Configuration;
@@ -26,12 +26,11 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
-import uk.org.webcompere.systemstubs.rules.SystemOutRule;
 import uk.org.webcompere.systemstubs.rules.SystemPropertiesRule;
 
 // See ensureInvalidNoException method for explanation of this rule.
 @RunWith(BMUnitRunner.class)
-@BMUnitConfig(verbose = true, bmunitVerbose = true)
+//@BMUnitConfig(verbose = true, bmunitVerbose = true)
 @BMRule(
         name = "override-inprocess-configuration",
         targetClass = "org.jboss.pnc.gradlemanipulator.common.Configuration",
@@ -40,9 +39,6 @@ import uk.org.webcompere.systemstubs.rules.SystemPropertiesRule;
         targetLocation = "AT ENTRY",
         action = "RETURN true")
 public class InvalidProjectPassFunctionalTest extends AbstractWiremockTest {
-
-    @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule();
 
     @Rule
     public final TestRule restoreSystemProperties = new SystemPropertiesRule();
@@ -79,7 +75,10 @@ public class InvalidProjectPassFunctionalTest extends AbstractWiremockTest {
         // System.setProperty("ignoreUnresolvableDependencies", "true");
 
         final File projectRoot = tempDir.newFolder("invalid-project");
-        final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
+        final TestManipulationModel alignmentModel = TestUtils.align(
+                projectRoot,
+                projectRoot.getName(),
+                Collections.singletonMap("scanProjectsWithNoPublications", "true"));
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
         assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot));

--- a/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/IvyDependencyFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/IvyDependencyFunctionalTest.java
@@ -15,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.commonjava.atlas.maven.ident.ref.ProjectVersionRef;
 import org.gradle.util.GradleVersion;
@@ -75,7 +76,7 @@ public class IvyDependencyFunctionalTest extends AbstractWiremockTest {
         final TestManipulationModel alignmentModel = TestUtils.align(
                 projectRoot,
                 projectRoot.getName(),
-                Collections.emptyMap());
+                Collections.singletonMap("scanProjectsWithNoPublications", "true"));
 
         assertThat(alignmentModel.findCorrespondingChild("root")).satisfies(root -> {
             assertThat(root.getVersion()).isEqualTo("1.0.1.redhat-00002");
@@ -96,11 +97,11 @@ public class IvyDependencyFunctionalTest extends AbstractWiremockTest {
         assumeTrue(GradleVersion.current().compareTo(GradleVersion.version("5.0")) >= 0);
 
         final File projectRoot = tempDir.newFolder("ivy-dependency");
-
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("scanProjectsWithNoPublications", "true");
+        properties.put("repoRemovalBackup", "");
         final File settings = new File(projectRoot, "settings.xml");
-        final Map<String, String> props = Collections.singletonMap("repoRemovalBackup", "");
-
-        final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName(), props);
+        final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName(), properties);
 
         assertThat(alignmentModel.findCorrespondingChild("root")).satisfies(root -> {
             assertThat(root.getVersion()).isEqualTo("1.0.1.redhat-00002");

--- a/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/KiotaProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/KiotaProjectFunctionalTest.java
@@ -1,0 +1,118 @@
+package org.jboss.pnc.gradlemanipulator.analyzer.alignment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Collections;
+import org.apache.commons.io.FileUtils;
+import org.commonjava.atlas.maven.ident.ref.ProjectVersionRef;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.gradle.util.GradleVersion;
+import org.jboss.pnc.gradlemanipulator.analyzer.alignment.TestUtils.TestManipulationModel;
+import org.jboss.pnc.gradlemanipulator.common.Configuration;
+import org.jboss.pnc.mavenmanipulator.io.rest.DefaultTranslator;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
+import uk.org.webcompere.systemstubs.rules.SystemOutRule;
+import uk.org.webcompere.systemstubs.rules.SystemPropertiesRule;
+
+public class KiotaProjectFunctionalTest extends AbstractWiremockTest {
+
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule();
+
+    @Rule
+    public final TestRule restoreSystemProperties = new SystemPropertiesRule();
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException, URISyntaxException {
+        stubFor(
+                post(urlEqualTo("/da/rest/v-1/" + DefaultTranslator.Endpoint.LOOKUP_GAVS))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader("Content-Type", "application/json;charset=utf-8")
+                                        .withBody(readSampleDAResponse("kiota-project-da-response.json"))));
+        stubFor(
+                post(urlEqualTo("/da/rest/v-1/" + DefaultTranslator.Endpoint.LOOKUP_LATEST))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader("Content-Type", "application/json;charset=utf-8")
+                                        .withBody(readSampleDAResponse("kiota-project-da-response-project.json"))));
+
+        System.setProperty(Configuration.DA, "http://127.0.0.1:" + wireMockRule.port() + "/da/rest/v-1");
+    }
+
+    @Test
+    public void ensureAlignmentFileCreated()
+            throws IOException, URISyntaxException, GitAPIException {
+        assumeTrue(GradleVersion.current().compareTo(GradleVersion.version("8.3")) >= 0);
+
+        final File projectRoot = tempDir.newFolder();
+
+        try (Git ignored = Git.cloneRepository()
+                .setURI("https://github.com/microsoft/kiota-java.git")
+                .setDirectory(projectRoot)
+                .setBranch("v1.9.0")
+                .setBranchesToClone(Collections.singletonList("refs/tags/v1.9.0"))
+                .setDepth(1)
+                .setNoTags()
+                .call()) {
+            System.out.println("Cloned Kiota to " + projectRoot);
+        }
+
+        FileUtils.copyDirectory(
+                Paths
+                        .get(TestUtils.class.getClassLoader().getResource("kiota-java-project").toURI())
+                        .toFile(),
+                projectRoot);
+
+        final TestManipulationModel alignmentModel = TestUtils.align(
+                projectRoot,
+                false);
+
+        assertThat(new File(projectRoot, AlignmentTask.GME)).exists();
+        assertThat(new File(projectRoot, AlignmentTask.GRADLE + File.separator + AlignmentTask.GME_REPOS)).exists();
+        assertThat(new File(projectRoot, AlignmentTask.GME_PLUGINCONFIGS)).exists();
+
+        assertThat(systemOutRule.getLinesNormalized()).contains(
+                "project ':components:serialization:json' is using an unspecified version; default to root project version of 1.9.0-SNAPSHOT");
+        assertThat(systemOutRule.getLinesNormalized()).contains(
+                "Project 'com.microsoft.kiota:kiota-java:1.9.0-SNAPSHOT' is defined but no publication ; skipping");
+
+        assertThat(alignmentModel).isNotNull().satisfies(am -> {
+            assertThat(am.getOriginalVersion()).isEqualTo("1.9.0-SNAPSHOT");
+            assertThat(am.getVersion()).isEqualTo("1.9.0.redhat-00002");
+            assertThat(am.getGroup()).isEqualTo("com.microsoft.kiota");
+            assertThat(am.getName()).isEqualTo("kiota-java");
+            assertThat(am.findCorrespondingChild(":components:serialization:json")).satisfies(root -> {
+                assertThat(root.getVersion()).isEqualTo("1.9.0.redhat-00002");
+                assertThat(root.getName()).isEqualTo("microsoft-kiota-serialization-json");
+                final Collection<ProjectVersionRef> alignedDependencies = root.getAlignedDependencies().values();
+                assertThat(alignedDependencies)
+                        .extracting("artifactId", "versionString")
+                        .containsOnly(
+                                tuple("jakarta.annotation-api", "2.1.1.redhat-00005"),
+                                tuple("slf4j-simple", "2.0.17.redhat-00001"));
+            });
+        });
+    }
+}

--- a/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/MicrometerProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/MicrometerProjectFunctionalTest.java
@@ -34,13 +34,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestRule;
-import uk.org.webcompere.systemstubs.rules.SystemOutRule;
 import uk.org.webcompere.systemstubs.rules.SystemPropertiesRule;
 
 public class MicrometerProjectFunctionalTest extends AbstractWiremockTest {
-
-    @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule();
 
     @Rule
     public final TestRule restoreSystemProperties = new SystemPropertiesRule();

--- a/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/MultiModuleProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/MultiModuleProjectFunctionalTest.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import org.apache.maven.settings.Repository;
 import org.apache.maven.settings.Settings;
@@ -90,7 +91,10 @@ public class MultiModuleProjectFunctionalTest extends AbstractWiremockTest {
         final File projectRoot = tempDir.newFolder("multi-module");
         new File(projectRoot, "subproject1/subproject11").mkdirs();
         new File(projectRoot, "subproject2").mkdirs();
-        final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
+        final TestManipulationModel alignmentModel = TestUtils.align(
+                projectRoot,
+                projectRoot.getName(),
+                Collections.singletonMap("scanProjectsWithNoPublications", "true"));
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
         assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot));
@@ -179,7 +183,8 @@ public class MultiModuleProjectFunctionalTest extends AbstractWiremockTest {
         new File(projectRoot.toFile(), "subproject2").mkdirs();
         final TestManipulationModel alignmentModel = TestUtils.align(
                 projectRoot.toFile(),
-                projectRoot.getFileName().toString());
+                projectRoot.getFileName().toString(),
+                Collections.singletonMap("scanProjectsWithNoPublications", "true"));
         assertThat(alignmentModel).isNotNull();
         final Path buildRoot = projectRoot.resolve("build");
         assertThat(buildRoot).isDirectory();
@@ -352,7 +357,8 @@ public class MultiModuleProjectFunctionalTest extends AbstractWiremockTest {
         new File(projectRoot.toFile(), "subproject2").mkdirs();
         final TestManipulationModel alignmentModel = TestUtils.align(
                 projectRoot.toFile(),
-                projectRoot.getFileName().toString());
+                projectRoot.getFileName().toString(),
+                Collections.singletonMap("scanProjectsWithNoPublications", "true"));
         assertThat(alignmentModel).isNotNull();
         final Path buildRoot = projectRoot.resolve("build");
         assertThat(buildRoot).isDirectory();
@@ -411,7 +417,8 @@ public class MultiModuleProjectFunctionalTest extends AbstractWiremockTest {
         new File(projectRoot.toFile(), "subproject2").mkdirs();
         final TestManipulationModel alignmentModel = TestUtils.align(
                 projectRoot.toFile(),
-                projectRoot.getFileName().toString());
+                projectRoot.getFileName().toString(),
+                Collections.singletonMap("scanProjectsWithNoPublications", "true"));
         assertThat(alignmentModel).isNotNull();
         final Path buildRoot = projectRoot.resolve("build");
         assertThat(buildRoot).isDirectory();

--- a/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/MultiModuleProjectWithOverridesFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/MultiModuleProjectWithOverridesFunctionalTest.java
@@ -63,7 +63,8 @@ public class MultiModuleProjectWithOverridesFunctionalTest
             .of(
                     Pair.of("dependencyOverride.junit:*@org.acme:subproject2", ""),
                     Pair.of("dependencyOverride.org.apache.commons:*@org.acme.subproject:*", "3.12.0.redhat-00002"),
-                    Pair.of("dependencyOverride.io.netty:netty-*@*", "4.1.72.Final-redhat-00001"))
+                    Pair.of("dependencyOverride.io.netty:netty-*@*", "4.1.72.Final-redhat-00001"),
+                    Pair.of("scanProjectsWithNoPublications", "true"))
             .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
 
     @Before

--- a/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/SimpleProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/SimpleProjectFunctionalTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
@@ -80,10 +81,13 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
     public void ensureAlignmentFileCreated() throws IOException, URISyntaxException, ManipulationException {
         final File projectRoot = tempDir.newFolder("simple-project");
 
+        Map<String, String> alignProps = new HashMap<>();
+        alignProps.put("scanProjectsWithNoPublications", "true");
+        alignProps.put("dependencyOverride.com.yammer.metrics:*@org.acme.gradle:root", "");
         final TestManipulationModel alignmentModel = TestUtils.align(
                 projectRoot,
                 projectRoot.getName(),
-                Collections.singletonMap("dependencyOverride.com.yammer.metrics:*@org.acme.gradle:root", ""));
+                alignProps);
 
         assertThat(new File(projectRoot, AlignmentTask.GME)).exists();
         assertThat(new File(projectRoot, AlignmentTask.GRADLE + File.separator + AlignmentTask.GME_REPOS)).exists();
@@ -190,7 +194,7 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
     }
 
     @Test
-    // @BMUnitConfig(verbose = true, bmunitVerbose = true)
+    //@BMUnitConfig(verbose = true, bmunitVerbose = true)
     @BMRule(
             name = "override-inprocess-configuration",
             targetClass = "org.jboss.pnc.gradlemanipulator.common.Configuration",
@@ -201,7 +205,10 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
     public void verifySingleGMEInjection() throws IOException, URISyntaxException, ManipulationException {
         final File projectRoot = tempDir.newFolder("simple-project");
 
-        TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
+        TestManipulationModel alignmentModel = TestUtils.align(
+                projectRoot,
+                projectRoot.getName(),
+                Collections.singletonMap("scanProjectsWithNoPublications", "true"));
 
         assertThat(new File(projectRoot, AlignmentTask.GME)).exists();
         assertEquals(AlignmentTask.INJECT_GME_START + " }", TestUtils.getLine(projectRoot));
@@ -249,7 +256,10 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
                                 "version=1.0.1-SNAPSHOT"),
                 Charset.defaultCharset());
 
-        final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, false);
+        final TestManipulationModel alignmentModel = TestUtils.align(
+                projectRoot,
+                false,
+                Collections.singletonMap("scanProjectsWithNoPublications", "true"));
 
         verify(
                 postRequestedFor(urlEqualTo("/da/rest/v-1/" + DefaultTranslator.Endpoint.LOOKUP_GAVS))
@@ -280,7 +290,8 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
         assertThat(projectRoot).isDirectory();
         final TestManipulationModel alignmentModel = TestUtils.align(
                 projectRoot.toFile(),
-                projectRoot.getFileName().toString());
+                projectRoot.getFileName().toString(),
+                Collections.singletonMap("scanProjectsWithNoPublications", "true"));
         assertThat(alignmentModel).isNotNull();
         final Path buildRoot = projectRoot.resolve("build");
         assertThat(buildRoot).isDirectory();
@@ -475,7 +486,8 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
         assertThat(projectRoot).isDirectory();
         final TestManipulationModel alignmentModel = TestUtils.align(
                 projectRoot.toFile(),
-                projectRoot.getFileName().toString());
+                projectRoot.getFileName().toString(),
+                Collections.singletonMap("scanProjectsWithNoPublications", "true"));
         assertThat(alignmentModel).isNotNull();
         final Path buildRoot = projectRoot.resolve("build");
         assertThat(buildRoot).isDirectory();
@@ -519,7 +531,8 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
         assertThat(projectRoot).isDirectory();
         final TestManipulationModel alignmentModel = TestUtils.align(
                 projectRoot.toFile(),
-                projectRoot.getFileName().toString());
+                projectRoot.getFileName().toString(),
+                Collections.singletonMap("scanProjectsWithNoPublications", "true"));
         assertThat(alignmentModel).isNotNull();
         final Path buildRoot = projectRoot.resolve("build");
         assertThat(buildRoot).isDirectory();
@@ -562,7 +575,9 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
                                 "version=0.1"),
                 Charset.defaultCharset());
 
-        final Map<String, String> gmeProps = Collections.singletonMap("versionOverride", "1.0.1");
+        final Map<String, String> gmeProps = new HashMap<>();
+        gmeProps.put("versionOverride", "1.0.1");
+        gmeProps.put("scanProjectsWithNoPublications", "true");
         final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName(), gmeProps);
 
         assertThat(new File(projectRoot, AlignmentTask.GME)).exists();

--- a/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/SimpleProjectWithCustomGroovyScriptFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/SimpleProjectWithCustomGroovyScriptFunctionalTest.java
@@ -14,8 +14,9 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.StringAssert;
 import org.commonjava.atlas.maven.ident.ref.ProjectVersionRef;
@@ -71,10 +72,13 @@ public class SimpleProjectWithCustomGroovyScriptFunctionalTest extends AbstractW
     public void verifyGroovyInjection() throws IOException, URISyntaxException, ManipulationException {
         final File projectRoot = tempDir.newFolder("simple-project-with-custom-groovy-script");
 
+        Map<String, String> alignProps = new HashMap<>();
+        alignProps.put("scanProjectsWithNoPublications", "true");
+        alignProps.put("groovyScripts", "file://" + projectRoot.getAbsolutePath() + "/gme.groovy");
         final TestManipulationModel alignmentModel = TestUtils.align(
                 projectRoot,
                 projectRoot.getName(),
-                Collections.singletonMap("groovyScripts", "file://" + projectRoot.getAbsolutePath() + "/gme.groovy"));
+                alignProps);
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
         assertTrue(new File(projectRoot, AlignmentTask.GME_PLUGINCONFIGS).exists());

--- a/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/SpringLikeLayoutFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/SpringLikeLayoutFunctionalTest.java
@@ -19,6 +19,8 @@ import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.commonjava.atlas.maven.ident.ref.ProjectVersionRef;
 import org.gradle.api.Project;
 import org.gradle.util.GradleVersion;
@@ -78,7 +80,10 @@ public class SpringLikeLayoutFunctionalTest extends AbstractWiremockTest {
         assumeTrue(GradleVersion.current().compareTo(GradleVersion.version("7.0")) < 0);
 
         final File projectRoot = tempDir.newFolder("spring-like-layout");
-        final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName());
+        final TestManipulationModel alignmentModel = TestUtils.align(
+                projectRoot,
+                projectRoot.getName(),
+                Collections.singletonMap("scanProjectsWithNoPublications", "true"));
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
         assertEquals(AlignmentTask.INJECT_GME_START, TestUtils.getLine(projectRoot));
@@ -144,11 +149,14 @@ public class SpringLikeLayoutFunctionalTest extends AbstractWiremockTest {
         // XXX: Caused by: java.lang.ClassNotFoundException: org.gradle.api.artifacts.maven.PomFilterContainer
         assumeTrue(GradleVersion.current().compareTo(GradleVersion.version("7.0")) < 0);
 
+        final Map<String, String> alignProps = new HashMap<>();
+        alignProps.put("scanProjectsWithNoPublications", "true");
+        alignProps.put("dokkaPlugin", "false");
         final File projectRoot = tempDir.newFolder("spring-like-layout");
         final TestManipulationModel alignmentModel = TestUtils.align(
                 projectRoot,
                 projectRoot.getName(),
-                Collections.singletonMap("dokkaPlugin", "false"));
+                alignProps);
 
         assertTrue(new File(projectRoot, AlignmentTask.GME).exists());
         assertEquals(AlignmentTask.INJECT_GME_START, TestUtils.getLine(projectRoot));

--- a/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/VersionConflictProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/VersionConflictProjectFunctionalTest.java
@@ -73,6 +73,7 @@ public class VersionConflictProjectFunctionalTest extends AbstractWiremockTest {
 
         final Map<String, String> map = new HashMap<>();
         map.put("overrideTransitive", "false");
+        map.put("scanProjectsWithNoPublications", "true");
         final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName(), map);
 
         assertThat(new File(projectRoot, AlignmentTask.GME)).exists();
@@ -129,6 +130,7 @@ public class VersionConflictProjectFunctionalTest extends AbstractWiremockTest {
 
         final Map<String, String> map = new HashMap<>();
         map.put("overrideTransitive", "true");
+        map.put("scanProjectsWithNoPublications", "true");
         final TestManipulationModel alignmentModel = TestUtils.align(projectRoot, projectRoot.getName(), map);
 
         assertThat(new File(projectRoot, AlignmentTask.GME)).exists();

--- a/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/WireProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/WireProjectFunctionalTest.java
@@ -37,13 +37,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestRule;
-import uk.org.webcompere.systemstubs.rules.SystemOutRule;
 import uk.org.webcompere.systemstubs.rules.SystemPropertiesRule;
 
 public class WireProjectFunctionalTest extends AbstractWiremockTest {
-
-    @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule();
 
     @Rule
     public final TestRule restoreSystemProperties = new SystemPropertiesRule();
@@ -107,6 +103,7 @@ public class WireProjectFunctionalTest extends AbstractWiremockTest {
         parameters.put("overrideTransitive", "true");
         parameters.put("org.gradle.java.home", JDK17_DIR.toString());
         parameters.put("ignoreUnresolvableDependencies", "true");
+        parameters.put("scanProjectsWithNoPublications", "true");
         parameters.put("kjs", "false");
         parameters.put("knative", "false");
         parameters.put("-Pswift", "false");

--- a/analyzer/src/functTest/resources/kiota-java-project/build.gradle
+++ b/analyzer/src/functTest/resources/kiota-java-project/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id "java-library"
+    alias(libs.plugins.org.sonarqube)
+    alias(libs.plugins.com.github.spotbugs)
+    alias(libs.plugins.com.diffplug.spotless)
+    id 'org.jboss.pnc.gradle-manipulator.analyzer'
+}
+
+allprojects {
+    apply plugin: 'org.jboss.pnc.gradle-manipulator.analyzer'
+}
+
+sonar {
+    properties {
+        property "sonar.projectKey", "microsoft_kiota-java"
+        property "sonar.organization", "microsoft"
+        property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.coverage.jacoco.xmlReportPaths", "${project.projectDir}/components/**/reports/jacoco/test/jacocoTestReport.xml"
+    }
+}
+
+subprojects {
+    apply plugin: 'org.sonarqube'
+}
+
+repositories {
+    mavenCentral()
+}
+
+group = project.property('mavenGroupId')
+version = "${mavenMajorVersion}.${mavenMinorVersion}.${mavenPatchVersion}${mavenCentralSnapshotArtifactSuffix}"

--- a/analyzer/src/functTest/resources/kiota-project-da-response-project.json
+++ b/analyzer/src/functTest/resources/kiota-project-da-response-project.json
@@ -1,0 +1,8 @@
+[
+  {
+    "latestVersion": "1.9.0.redhat-00001",
+    "version": "1.9.0",
+    "groupId": "com.microsoft.kiota",
+    "artifactId": "microsoft-kiota-http-okHttp"
+  }
+]

--- a/analyzer/src/functTest/resources/kiota-project-da-response.json
+++ b/analyzer/src/functTest/resources/kiota-project-da-response.json
@@ -1,0 +1,14 @@
+[
+  {
+    "bestMatchVersion": "2.0.17.redhat-00001",
+    "version": "2.0.17",
+    "groupId" : "org.slf4j",
+    "artifactId" : "slf4j-simple"
+  },
+  {
+    "bestMatchVersion": "2.1.1.redhat-00005",
+    "version": "2.1.1",
+    "groupId" : "jakarta.annotation",
+    "artifactId" : "jakarta.annotation-api"
+  }
+]

--- a/analyzer/src/main/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/AlignmentTask.java
+++ b/analyzer/src/main/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/AlignmentTask.java
@@ -206,7 +206,7 @@ public class AlignmentTask extends DefaultTask {
             if (DefaultProject.DEFAULT_VERSION.equals(project.getVersion())) {
                 currentProjectVersion = project.getRootProject().getVersion().toString();
                 logger.warn(
-                        "Project {} is using an unspecified version; default to root project version of {}",
+                        "Module {} is using an unspecified version; default to root project version of {}",
                         project,
                         currentProjectVersion);
                 project.setVersion(currentProjectVersion);

--- a/analyzer/src/main/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/AlignmentTask.java
+++ b/analyzer/src/main/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/AlignmentTask.java
@@ -59,6 +59,7 @@ import org.gradle.api.attributes.Attribute;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedDependencyResult;
 import org.gradle.api.internal.plugins.DefaultPluginManager;
+import org.gradle.api.internal.project.DefaultProject;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.AppliedPlugin;
 import org.gradle.api.publish.PublishingExtension;
@@ -188,6 +189,7 @@ public class AlignmentTask extends DefaultTask {
         final ManipulationCache cache = ManipulationCache.getCache(project);
         final Path root = project.getRootDir().toPath();
         final ManipulationModel alignmentModel = cache.getModel();
+        boolean skipProject = false;
 
         // Only output the config once to avoid noisy logging.
         if (logger.isInfoEnabled() && !configOutput.get().getAndSet(true)) {
@@ -196,16 +198,26 @@ public class AlignmentTask extends DefaultTask {
 
         String groupId = ProjectUtils.getRealGroupId(project);
         String projectName = project.getName();
-
         final String currentProjectVersion;
+
         if (configuration.versionOverride() != null) {
             currentProjectVersion = configuration.versionOverride();
         } else {
-            currentProjectVersion = project.getVersion().toString();
+            if (DefaultProject.DEFAULT_VERSION.equals(project.getVersion())) {
+                currentProjectVersion = project.getRootProject().getVersion().toString();
+                logger.warn(
+                        "Project {} is using an unspecified version; default to root project version of {}",
+                        project,
+                        currentProjectVersion);
+                project.setVersion(currentProjectVersion);
+            } else {
+                currentProjectVersion = project.getVersion().toString();
+            }
         }
         logger.info(
-                "Starting alignment task for project in directory '{}' with GAV {}:{}:{}",
-                project.getProjectDir().getName(),
+                "Starting alignment task for project {} with path '{}' with GAV {}:{}:{}",
+                project,
+                project.getProjectDir().getPath(),
                 groupId,
                 projectName,
                 currentProjectVersion);
@@ -231,6 +243,13 @@ public class AlignmentTask extends DefaultTask {
                         .getAsMap());
         if (publications.size() > 1) {
             logger.error("Multiple publications for a single project. Found {}", publications);
+        } else if (publications.isEmpty()) {
+            // Only skip a module with no publications if the configuration flag is not enabled. This
+            // flag is primarily useful for regression tests where handcrafted build files might not
+            // have publications defined yet we still want to align them to test various scenarios.
+            if (!configuration.scanProjectsWithNoPublications()) {
+                skipProject = true;
+            }
         }
         Optional<Map.Entry<String, MavenPublication>> entry = publications.entrySet().stream().findFirst();
         if (entry.isPresent()) {
@@ -296,10 +315,15 @@ public class AlignmentTask extends DefaultTask {
                                     org.jboss.pnc.gradlemanipulator.common.utils.FileUtils
                                             .relativize(root, project.getProjectDir().toPath())));
 
-            if (StringUtils.isBlank(groupId) ||
-                    DEFAULT_VERSION.equals(currentProjectVersion)) {
+            if (StringUtils.isBlank(groupId)) {
                 logger.warn(
-                        "Project '{}:{}:{}' is not fully defined ; skipping. ",
+                        "Project '{}:{}:{}' is not fully defined ; skipping.",
+                        groupId,
+                        projectName,
+                        currentProjectVersion);
+            } else if (skipProject) {
+                logger.warn(
+                        "Project '{}:{}:{}' is defined but no publication ; skipping.",
                         groupId,
                         projectName,
                         currentProjectVersion);
@@ -383,6 +407,7 @@ public class AlignmentTask extends DefaultTask {
                 .sorted(comparingInt(AlignmentService.Manipulator::order))
                 .collect(Collectors.toList());
 
+        // Call the alignment service
         final Response alignmentResponse = alignmentService.align(
                 new AlignmentService.Request(
                         cache.getProjectVersionRefs(configuration.versionSuffixSnapshot()),

--- a/analyzer/src/main/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/DAAlignmentService.java
+++ b/analyzer/src/main/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/DAAlignmentService.java
@@ -115,6 +115,9 @@ public class DAAlignmentService implements AlignmentService {
             logger.info("Retrieving project version {} and returning {}", projectVersion, newProjectVersion);
 
             response.getTranslationMap().putAll(pMap);
+            // Equivalent to versionModification && pParams.isEmpty()
+        } else if (versionModification) {
+            logger.warn("Version modification enabled but no project GAVs found");
         }
 
         return response;

--- a/analyzer/src/main/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/UpdateProjectVersionCustomizer.java
+++ b/analyzer/src/main/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/UpdateProjectVersionCustomizer.java
@@ -88,11 +88,24 @@ public class UpdateProjectVersionCustomizer implements AlignmentService.Manipula
             }
         }
 
-        // Set any that are 'unspecified' to the default project version.
+        // Previously this set any modules that are 'unspecified' to the default project
+        // version. With NCLSUP1402 the AlignmentTask::perform now updates project
+        // versions while also handling those projects with no publications. This check
+        // should therefore no longer be required.
+        // However, as its theoretically possible to disable the changes via the
+        // "scanProjectsWithNoPublications" property I'll keep this check as it should be
+        // harmless.
         rootProject.getAllprojects()
                 .stream()
                 .filter(f -> DefaultProject.DEFAULT_VERSION.equals(f.getVersion()))
-                .forEach(p -> projectsToVersions.put(p, newVersion[0]));
+                .forEach(project -> {
+                    // This should not happen but update the version anyway.
+                    logger.error(
+                            "Found project with unspecified version. Project: {} in directory {}",
+                            project,
+                            project.getProjectDir().getPath());
+                    projectsToVersions.put(project, newVersion[0]);
+                });
     }
 
     private class GradleVersionCalculator extends VersionCalculator {

--- a/analyzer/src/main/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/UpdateProjectVersionCustomizer.java
+++ b/analyzer/src/main/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/UpdateProjectVersionCustomizer.java
@@ -101,7 +101,7 @@ public class UpdateProjectVersionCustomizer implements AlignmentService.Manipula
                 .forEach(project -> {
                     // This should not happen but update the version anyway.
                     logger.error(
-                            "Found project with unspecified version. Project: {} in directory {}",
+                            "Found project with unspecified version. Module: {} in directory {}",
                             project,
                             project.getProjectDir().getPath());
                     projectsToVersions.put(project, newVersion[0]);

--- a/analyzer/src/test/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/AlignmentTaskEmptyVersionTest.java
+++ b/analyzer/src/test/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/AlignmentTaskEmptyVersionTest.java
@@ -33,7 +33,6 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.gradle.util.GradleVersion;
 import org.jboss.byteman.contrib.bmunit.BMRule;
-import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.jboss.pnc.gradlemanipulator.analyzer.alignment.io.SettingsFileIO;
 import org.jboss.pnc.gradlemanipulator.common.Configuration;
@@ -49,7 +48,7 @@ import uk.org.webcompere.systemstubs.rules.SystemOutRule;
 import uk.org.webcompere.systemstubs.rules.SystemPropertiesRule;
 
 @RunWith(BMUnitRunner.class)
-@BMUnitConfig(bmunitVerbose = true)
+//@BMUnitConfig(bmunitVerbose = true)
 @BMRule(
         name = "handle-injectIntoNewInstance",
         targetClass = "org.gradle.api.internal.AbstractTask",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -272,7 +272,7 @@ subprojects {
     // Note - this *downgrades* Jackson from what is used in PME. This is due to
     // https://github.com/gradle/gradle/issues/24390
     // https://github.com/FasterXML/jackson-core/issues/955
-    // This exclusion isn't required on 7.6.1 and above.
+    // This exclusion isn't required on 7.6.4 and above.
     extra["jacksonVersion"] = "2.14.3"
     // Must use 6.x series as 7.x and above require JDK17
     extra["jgitVersion"] = "6.10.1.202505221210-r"
@@ -556,7 +556,8 @@ subprojects {
         slowThreshold = 120000
         // Nicer looking theme than default.
         theme = ThemeType.MOCHA
-        showStandardStreams = true
+        // Ensure everything goes to log files not console.
+        showStandardStreams = false
         showPassedStandardStreams = false
         showSkippedStandardStreams = false
     }

--- a/common/src/main/java/org/jboss/pnc/gradlemanipulator/common/Configuration.java
+++ b/common/src/main/java/org/jboss/pnc/gradlemanipulator/common/Configuration.java
@@ -189,6 +189,17 @@ public interface Configuration extends Accessible, Reloadable {
     Boolean useLegacyConfigurationCopy();
 
     /**
+     * This is primarily used by the tests. Since NCLSUP-1402 we skip projects with no publication when scanning
+     * for alignment. However, many integration tests predate that and the publications have not been added. This
+     * allows those projects to be scanned for alignment even if they don't publish anything. Defaults to false.
+     *
+     * @return a boolean denoting whether to allow scanning for GAV changes on non-published projects
+     */
+    @Key("scanProjectsWithNoPublications")
+    @DefaultValue("false")
+    boolean scanProjectsWithNoPublications();
+
+    /**
      * Whether to explicitly override all transitive dependencies as well. Defaults to false.
      * <p>
      * This method is purposely <b>not</b> annotated with a <code>DefaultValue</code> so that


### PR DESCRIPTION
This fixes the problem with choosing a GAV from the project to get the `bestMatchVersion` for from DA. The issue was that if we pick e.g. the root project, and that is **not** published then it will always return a no-match. We need to pick a published project. However, if the published submodules have a `unspecified`, then originally we would skip them and their version would be fixed up in `UpdateProjectVersionCustomizer`. To solve this we now update the `unspecified` version early using a default of the root project version. This still allows the version customizer to update the version according to the REST results. A hidden property (`scanProjectsWithNoPublications`) has also been added as many of the integration tests are hand-crafted and don't contain publications - but we still want to do alignment with them to verify various scenarios.