### PR TITLE
Simplify action definition

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,11 +35,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - name: Remove default github maven configuration
-        # This step is a workaround to avoid a decryption issue of Beam's
-        # net.linguica.gradle.maven.settings plugin and github's provided maven
-        # settings.xml file
-        run: rm ~/.m2/settings.xml
       - name: Check Java formatting
         uses: gradle/gradle-build-action@v3
         with:
@@ -62,20 +57,12 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 11
-    - name: Remove default github maven configuration
-      # This step is a workaround to avoid a decryption issue of Beam's
-      # net.linguica.gradle.maven.settings plugin and github's provided maven
-      # settings.xml file
-      run: rm ~/.m2/settings.xml
     - name: Fix build for Gradle ${{ matrix.gradle }}
       run: ./gradle/fix-build.sh ${{ matrix.gradle }}
     - uses: gradle/gradle-build-action@v3
       with:
         gradle-version: ${{ matrix.gradle }}
         arguments: --no-daemon --stacktrace clean build AggregateJacocoReport
-    # - name: Setup tmate session
-    #   uses: mxschmitt/action-tmate@v3
-    #   if: ${{ failure() }}
     - name: Codecov
       uses: codecov/codecov-action@v6
       with:
@@ -97,18 +84,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - name: Remove default github maven configuration
-        # This step is a workaround to avoid a decryption issue of Beam's
-        # net.linguica.gradle.maven.settings plugin and github's provided maven
-        # settings.xml file
-        run: rm ~/.m2/settings.xml
       - uses: gradle/gradle-build-action@v3
         with:
           gradle-version: ${{ matrix.gradle }}
           arguments: --no-daemon --stacktrace clean build AggregateJacocoReport
-      # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
-      #   if: ${{ failure() }}
       - name: Codecov
         uses: codecov/codecov-action@v6
         with:
@@ -126,23 +105,9 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 17
-    - name: Remove default github maven configuration
-      # This step is a workaround to avoid a decryption issue of Beam's
-      # net.linguica.gradle.maven.settings plugin and github's provided maven
-      # settings.xml file
-      run: rm ~/.m2/settings.xml
-    # https://github.com/marketplace/actions/maven-setings-action
-    - name: Maven Settings
-      uses: s4u/maven-settings-action@v4.0.0
-      with:
-        sonatypeSnapshots: true
-        githubServer: false
-        servers: |
-            [{
-                "id": "central",
-                "username": "${{ secrets.SONATYPE_USERNAME }}",
-                "password": "${{ secrets.SONATYPE_PASSWORD }}"
-            }]
+        server-id: central-publisher      # we use this in our pom.xml
+        server-username: MAVEN_USERNAME   # env var name for username
+        server-password:  MAVEN_PASSWORD  # env var name for password
     - name: Extract Project version
       id: project-version
       run: echo "version=$(cat gradle.properties | awk -F "=" 'BEGIN{ORS=""} /version/{print $NF}')" >> "$GITHUB_OUTPUT"
@@ -150,3 +115,6 @@ jobs:
       if:  ${{ endsWith(steps.project-version.outputs.version, '-SNAPSHOT') }}
       with:
         arguments: build publishToCentral -x test -x funcTest
+      env:
+        MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,13 +8,9 @@ import java.nio.file.StandardCopyOption
 import java.text.SimpleDateFormat
 import java.util.Date
 import kotlin.reflect.full.memberFunctions
-import net.linguica.gradle.maven.settings.LocalMavenSettingsLoader
-import net.linguica.gradle.maven.settings.MavenSettingsPlugin.MAVEN_SETTINGS_EXTENSION_NAME
-import net.linguica.gradle.maven.settings.MavenSettingsPluginExtension
 import org.ajoberstar.grgit.Grgit
-import org.apache.maven.settings.building.SettingsBuildingException
 import org.gradle.kotlin.dsl.project
-import io.github.mhoffrog.gradle.maven.settings.scope.impl.GradlePluginProjectScopeUtilizer
+
 plugins {
     java
     signing
@@ -37,13 +33,6 @@ plugins {
     }
     id("net.researchgate.release") version "2.8.1"
     id("org.ajoberstar.grgit") version "4.1.1"
-    // Were using mark-vieira/gradle-maven-settings-plugin but due to
-    // https://github.com/mark-vieira/gradle-maven-settings-plugin/issues/29 it doesn't work with Gradle >= 8.2
-    // We then tried rmanibus/gradle-maven-settings-plugin but that still has decrypt issue:
-    // https://github.com/mark-vieira/gradle-maven-settings-plugin/issues/15
-    // Try another fork (We really only need minimal code from it anyway).
-    // id("io.github.rmanibus.maven-settings") version "0.8" apply false
-    id("io.github.mavenplugins.gradle.maven-settings") version "1.1.0" apply false
 
     when {
         GradleVersion.current() < GradleVersion.version("5.0") -> {
@@ -625,30 +614,6 @@ fun MavenPublication.generatePom() {
     }
 }
 
-fun loadSettings(extension: MavenSettingsPluginExtension, repository: String) {
-    val settingsLoader = LocalMavenSettingsLoader(extension)
-    try {
-        val settings = settingsLoader.loadSettings()
-        for (server in settings.servers) {
-            logger.debug("Settings parser examining server {}", server.id)
-            if (repository == server.id) {
-                if (server.username != null && server.password != null) {
-                    logger.info("Found valid credentials for publishing")
-                    // As the nmcp configuration has been moved to a separate groovy file
-                    // instead of returning a Pair<String,String> store the values in the ext.
-                    project.ext.set("central_username", server.username)
-                    project.ext.set("central_password", server.password)
-                    return
-                }
-            }
-        }
-    } catch (e: SettingsBuildingException) {
-        throw GradleScriptException("Unable to read local Maven settings.", e)
-    }
-    project.ext.set("central_username", "")
-    project.ext.set("central_password", "")
-}
-
 val isReleaseBuild = ("true" == gradle.startParameter.projectProperties.getOrDefault("release", ""))
 
 if (isReleaseBuild && GradleVersion.current().version != "${project.extra.get("gradleReleaseVersion")}") {
@@ -664,17 +629,11 @@ if (System.getProperty("release") != null) {
 if (GradleVersion.current() >= GradleVersion.version("8.3")) {
     // LinkageError: loader constraint violation from GMEFunctionalTest otherwise
     if (System.getProperty("gmeFunctionalTest") == null) {
-        val mavenExtension =
-                project.extensions.create(MAVEN_SETTINGS_EXTENSION_NAME, MavenSettingsPluginExtension::class,
-                    GradlePluginProjectScopeUtilizer(project))
-        // Previously was encoding the repository name into repositories that were attached to the
-        // publications. As those aren't needed now due to Central portal upload changes, just
-        // hardcode the name here. This should match the name in $HOME/.m2/settings.xml
-        loadSettings(mavenExtension, "central-publisher")
         // We have to delay applying the plugin and load the extension configuration from a groovy file as:
         // 1. We can't use the plugin on other JDK/Gradle combinations
         // 2. We can't use Kotlin types in external files (https://github.com/gradle/gradle/issues/30878) and we
         //    don't want them eagerly precompiled anyway.
+        // 3. The MavenSettingsPlugin is applied in nmcp.gradle to load credentials from Maven settings.xml
         apply(plugin = "com.gradleup.nmcp.aggregation")
         apply { from("$rootDir/gradle/nmcp.gradle") }
         project.rootProject.tasks.register("publishToCentral") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ import net.linguica.gradle.maven.settings.MavenSettingsPluginExtension
 import org.ajoberstar.grgit.Grgit
 import org.apache.maven.settings.building.SettingsBuildingException
 import org.gradle.kotlin.dsl.project
-
+import io.github.mhoffrog.gradle.maven.settings.scope.impl.GradlePluginProjectScopeUtilizer
 plugins {
     java
     signing
@@ -39,8 +39,11 @@ plugins {
     id("org.ajoberstar.grgit") version "4.1.1"
     // Were using mark-vieira/gradle-maven-settings-plugin but due to
     // https://github.com/mark-vieira/gradle-maven-settings-plugin/issues/29 it doesn't work with Gradle >= 8.2
-    // We really only need minimal code from it anyway
-    id("io.github.rmanibus.maven-settings") version "0.8" apply false
+    // We then tried rmanibus/gradle-maven-settings-plugin but that still has decrypt issue:
+    // https://github.com/mark-vieira/gradle-maven-settings-plugin/issues/15
+    // Try another fork (We really only need minimal code from it anyway).
+    // id("io.github.rmanibus.maven-settings") version "0.8" apply false
+    id("io.github.mavenplugins.gradle.maven-settings") version "1.1.0" apply false
 
     when {
         GradleVersion.current() < GradleVersion.version("5.0") -> {
@@ -662,11 +665,12 @@ if (GradleVersion.current() >= GradleVersion.version("8.3")) {
     // LinkageError: loader constraint violation from GMEFunctionalTest otherwise
     if (System.getProperty("gmeFunctionalTest") == null) {
         val mavenExtension =
-            project.extensions.create(MAVEN_SETTINGS_EXTENSION_NAME, MavenSettingsPluginExtension::class, project)
+                project.extensions.create(MAVEN_SETTINGS_EXTENSION_NAME, MavenSettingsPluginExtension::class,
+                    GradlePluginProjectScopeUtilizer(project))
         // Previously was encoding the repository name into repositories that were attached to the
         // publications. As those aren't needed now due to Central portal upload changes, just
         // hardcode the name here. This should match the name in $HOME/.m2/settings.xml
-        loadSettings(mavenExtension, "central")
+        loadSettings(mavenExtension, "central-publisher")
         // We have to delay applying the plugin and load the extension configuration from a groovy file as:
         // 1. We can't use the plugin on other JDK/Gradle combinations
         // 2. We can't use Kotlin types in external files (https://github.com/gradle/gradle/issues/30878) and we

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.apache.maven:maven-settings:3.9.12")
+    implementation("org.apache.maven:maven-settings-builder:3.9.12")
+}

--- a/buildSrc/src/main/kotlin/MavenSettingsPlugin.kt
+++ b/buildSrc/src/main/kotlin/MavenSettingsPlugin.kt
@@ -1,0 +1,52 @@
+import org.apache.maven.settings.Settings
+import org.apache.maven.settings.building.DefaultSettingsBuilder
+import org.apache.maven.settings.building.DefaultSettingsBuilderFactory
+import org.apache.maven.settings.building.DefaultSettingsBuildingRequest
+import org.apache.maven.settings.building.SettingsBuildingException
+import org.apache.maven.settings.building.SettingsBuildingRequest
+import org.apache.maven.settings.building.SettingsBuildingResult
+import org.gradle.api.GradleScriptException
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import java.io.File
+
+open class MavenSettingsPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.extensions.create("mavenSettings", MavenSettingsExtension::class.java, project)
+    }
+}
+
+open class MavenSettingsExtension(private val project: Project) {
+    
+    fun loadSettings(repository: String) {
+        try {
+            val settingsBuildingRequest: SettingsBuildingRequest = DefaultSettingsBuildingRequest()
+            settingsBuildingRequest.userSettingsFile = project.file(File(System.getProperty("user.home"), ".m2/settings.xml"))
+            settingsBuildingRequest.systemProperties = System.getProperties()
+
+            val factory = DefaultSettingsBuilderFactory()
+            val settingsBuilder: DefaultSettingsBuilder = factory.newInstance()
+            val settingsBuildingResult: SettingsBuildingResult = settingsBuilder.build(settingsBuildingRequest)
+            val settings: Settings = settingsBuildingResult.effectiveSettings
+            
+            for (server in settings.servers) {
+                project.logger.debug("Settings parser examining server {}", server.id)
+                if (repository == server.id) {
+                    if (server.username != null && server.password != null) {
+                        project.logger.info("Found valid credentials for publishing")
+                        // Store the values in the project ext
+                        project.extensions.extraProperties.set("central_username", server.username)
+                        project.extensions.extraProperties.set("central_password", server.password)
+                        return
+                    }
+                }
+            }
+        } catch (e: SettingsBuildingException) {
+            throw GradleScriptException("Unable to read local Maven settings.", e)
+        }
+        project.extensions.extraProperties.set("central_username", "")
+        project.extensions.extraProperties.set("central_password", "")
+    }
+}
+
+// Made with Bob

--- a/gradle/nmcp.gradle
+++ b/gradle/nmcp.gradle
@@ -1,5 +1,12 @@
-// Configuration for https://github.com/GradleUp/nmcp
 
+// Apply the Maven settings plugin to load credentials
+apply plugin: MavenSettingsPlugin
+
+// Load credentials from Maven settings.xml
+// This should match the name in $HOME/.m2/settings.xml
+rootProject.extensions.getByType(MavenSettingsExtension).loadSettings("central-publisher")
+
+// Configuration for https://github.com/GradleUp/nmcp
 nmcpAggregation {
     centralPortal {
         // publish manually from the portal


### PR DESCRIPTION
Currently the gh action workflow has to delete the predefined settings.xml to avoid failures with the maven settings plugin. This problem would still occur if we generate the settings via the java plugin as per how the rest of the PNC shared actions work. So, using Bob I've extracted the relevant part and avoided the issue with decryption. However I've had to make it a buildSrc plugin and use groovy to avoid kotlin early interpretation.