### PR TITLE
Append GME repos injection to settings.gradle instead of prepending

### DIFF
--- a/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/SimpleProjectFunctionalTest.java
+++ b/analyzer/src/functTest/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/SimpleProjectFunctionalTest.java
@@ -126,6 +126,16 @@ public class SimpleProjectFunctionalTest extends AbstractWiremockTest {
                 .filteredOn(l -> l.trim().equals(AlignmentTask.APPLY_GME_REPOS))
                 .hasSize(1);
 
+        // verify that settings.gradle in gradle/plugins has injection appended (not prepended)
+        extraGradleFile = projectRoot.toPath().resolve("gradle/plugins/settings.gradle").toFile();
+        assertThat(extraGradleFile).exists();
+        List<String> settingsLines = FileUtils.readLines(extraGradleFile, Charset.defaultCharset());
+        assertThat(settingsLines)
+                .filteredOn(l -> l.trim().equals(AlignmentTask.APPLY_GME_REPOS))
+                .hasSize(1);
+        assertThat(settingsLines.get(0).trim()).startsWith("pluginManagement");
+        assertThat(settingsLines.get(settingsLines.size() - 1).trim()).isEqualTo(AlignmentTask.APPLY_GME_REPOS);
+
         // Verify the org.gradle.caching has been removed.
         File properties = new File(projectRoot, "gradle.properties");
         assertThat(linesOf(properties)).anyMatch(value -> !value.contains("org.gradle.caching"));

--- a/analyzer/src/functTest/resources/simple-project/gradle/plugins/settings.gradle
+++ b/analyzer/src/functTest/resources/simple-project/gradle/plugins/settings.gradle
@@ -1,0 +1,5 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+}

--- a/analyzer/src/main/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/AlignmentTask.java
+++ b/analyzer/src/main/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/AlignmentTask.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 import org.aeonbits.owner.ConfigCache;
 import org.apache.commons.beanutils.ContextClassLoaderLocal;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.apache.commons.io.filefilter.NameFileFilter;
@@ -721,7 +722,7 @@ public class AlignmentTask extends DefaultTask {
                 DirectoryFileFilter.DIRECTORY);
         for (File extraGradleScript : extraGradleScripts) {
             final List<String> lines = FileUtils.readLines(extraGradleScript, Charset.defaultCharset());
-            if (extraGradleScript.getName().startsWith("settings")) {
+            if (FilenameUtils.getBaseName(extraGradleScript.getName()).equals("settings")) {
                 if (!APPLY_GME_REPOS
                         .equals(
                                 org.jboss.pnc.gradlemanipulator.common.utils.FileUtils.getLastLine(

--- a/analyzer/src/main/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/AlignmentTask.java
+++ b/analyzer/src/main/java/org/jboss/pnc/gradlemanipulator/analyzer/alignment/AlignmentTask.java
@@ -721,7 +721,19 @@ public class AlignmentTask extends DefaultTask {
                 DirectoryFileFilter.DIRECTORY);
         for (File extraGradleScript : extraGradleScripts) {
             final List<String> lines = FileUtils.readLines(extraGradleScript, Charset.defaultCharset());
-            if (!APPLY_GME_REPOS.equals(org.jboss.pnc.gradlemanipulator.common.utils.FileUtils.getFirstLine(lines))) {
+            if (extraGradleScript.getName().startsWith("settings")) {
+                if (!APPLY_GME_REPOS
+                        .equals(
+                                org.jboss.pnc.gradlemanipulator.common.utils.FileUtils.getLastLine(
+                                        extraGradleScript))) {
+                    final List<String> result = new ArrayList<>(lines.size() + 2);
+                    result.addAll(lines);
+                    result.add(System.lineSeparator());
+                    result.add(APPLY_GME_REPOS);
+                    FileUtils.writeLines(extraGradleScript, result);
+                }
+            } else if (!APPLY_GME_REPOS
+                    .equals(org.jboss.pnc.gradlemanipulator.common.utils.FileUtils.getFirstLine(lines))) {
                 final List<String> result = new ArrayList<>(lines.size() + 2);
                 result.add(APPLY_GME_REPOS);
                 result.add(System.lineSeparator());


### PR DESCRIPTION
## Summary
- Fixes #552 — `updateAllExtraGradleFilesWithGmeRepos` now **appends** the `APPLY_GME_REPOS` block to `settings.gradle` files instead of prepending, preserving the required `pluginManagement {}` first-statement ordering
- Adds a `gradle/plugins/settings.gradle` test resource with a `pluginManagement` block and assertions verifying injection is appended
- I've checked and it appears that settings.gradle is the only .gradle file that requires an alternate ordering where plugins or buildscript are not first

## Test plan
- [x] `SimpleProjectFunctionalTest.verifySingleGMEInjection` verifies `pluginManagement` stays first and `APPLY_GME_REPOS` is appended last in `gradle/plugins/settings.gradle`
- [x] All existing functional tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)