### PR TITLE
Fix DifferentJVMTest to support macOS

### DIFF
--- a/common/src/testFixtures/java/org/jboss/pnc/gradlemanipulator/common/JVMTestSetup.java
+++ b/common/src/testFixtures/java/org/jboss/pnc/gradlemanipulator/common/JVMTestSetup.java
@@ -15,20 +15,49 @@ import org.jboss.pnc.mavenmanipulator.common.ManipulationUncheckedException;
 public class JVMTestSetup {
     public static final Path GRADLE_JDK_HOME = Paths.get(System.getProperty("user.home"), ".gradle", "jdks");
 
+    private static final String OS_NAME;
+    private static final String ARCH;
+    private static final String HOME_SUBDIR;
+
+    static {
+        if (SystemUtils.IS_OS_LINUX) {
+            OS_NAME = "linux";
+            ARCH = "x64";
+            HOME_SUBDIR = "";
+        } else if (SystemUtils.IS_OS_MAC) {
+            OS_NAME = "mac";
+            ARCH = System.getProperty("os.arch").contains("aarch64") || System.getProperty("os.arch").contains("arm64")
+                    ? "aarch64"
+                    : "x64";
+            HOME_SUBDIR = "Contents/Home";
+        } else {
+            throw new ManipulationUncheckedException("Unsupported OS: " + System.getProperty("os.name"));
+        }
+    }
+
+    // JDK 8 aarch64 macOS builds don't exist; use x64 via Rosetta
+    private static final String JDK8_ARCH = SystemUtils.IS_OS_MAC ? "x64" : ARCH;
+
     public static final String JDK8_BASEDIR = "jdk8u272-b10";
 
-    public static final Path JDK8_DIR = GRADLE_JDK_HOME.resolve(JDK8_BASEDIR);
+    private static final Path JDK8_EXTRACT_DIR = GRADLE_JDK_HOME.resolve(JDK8_BASEDIR);
+
+    public static final Path JDK8_DIR = HOME_SUBDIR.isEmpty() ? JDK8_EXTRACT_DIR
+            : JDK8_EXTRACT_DIR.resolve(HOME_SUBDIR);
 
     public static final Path JDK8_BIN_DIR = JDK8_DIR.resolve("bin");
 
     public static final String JDK17_BASEDIR = "jdk-17.0.12+7";
 
-    public static final Path JDK17_DIR = GRADLE_JDK_HOME.resolve(JDK17_BASEDIR);
+    private static final Path JDK17_EXTRACT_DIR = GRADLE_JDK_HOME.resolve(JDK17_BASEDIR);
+
+    public static final Path JDK17_DIR = HOME_SUBDIR.isEmpty() ? JDK17_EXTRACT_DIR
+            : JDK17_EXTRACT_DIR.resolve(HOME_SUBDIR);
 
     public static final Path JDK17_BIN_DIR = JDK17_DIR.resolve("bin");
 
     /**
-     * This method will, on Linux, download and cache if it doesn't exist JDK8 and 17 installations.
+     * This method will download and cache if it doesn't exist JDK8 and 17 installations.
      * <br/>
      * This location ($HOME/.gradle/jdks) was chosen to match the
      * <a href="https://docs.gradle.org/current/userguide/toolchains.html">Gradle toolchain default</a>.
@@ -38,13 +67,9 @@ public class JVMTestSetup {
         String filename;
         UnArchiver ua = new TarGZipUnArchiver();
 
-        if (!SystemUtils.IS_OS_LINUX) {
-            throw new ManipulationUncheckedException("Unknown OS");
-        }
-
         if (!Files.exists(JDK8_BIN_DIR)) {
-            Files.createDirectories(JDK8_DIR);
-            filename = "OpenJDK8U-jdk_x64_linux_hotspot_8u272b10.tar.gz";
+            Files.createDirectories(JDK8_EXTRACT_DIR);
+            filename = "OpenJDK8U-jdk_" + JDK8_ARCH + "_" + OS_NAME + "_hotspot_8u272b10.tar.gz";
 
             Path destFile = GRADLE_JDK_HOME.resolve(filename);
 
@@ -63,8 +88,8 @@ public class JVMTestSetup {
             ua.extract();
         }
         if (!Files.exists(JDK17_BIN_DIR)) {
-            Files.createDirectories(JDK17_DIR);
-            filename = "OpenJDK17U-jdk_x64_linux_hotspot_17.0.12_7.tar.gz";
+            Files.createDirectories(JDK17_EXTRACT_DIR);
+            filename = "OpenJDK17U-jdk_" + ARCH + "_" + OS_NAME + "_hotspot_17.0.12_7.tar.gz";
 
             Path destFile = GRADLE_JDK_HOME.resolve(filename);
 


### PR DESCRIPTION
## Summary
- `JVMTestSetup` was hardcoded for Linux (`x64_linux` archive filenames, no `Contents/Home` subdir), causing `DifferentJVMTest` to fail on macOS.
- Detect OS and architecture at class-load time so the correct Adoptium archive is downloaded on macOS — including `aarch64` for Apple Silicon on JDK 17 and `x64` via Rosetta for JDK 8 (where no aarch64 build exists).
- Resolve JDK home through `Contents/Home` on macOS to match the Adoptium tarball layout.

@rnc I don't have a Linux box - I wasn't able to test if anything regresses on Linux with this change - I'm hoping it runs cleanly on Linux with these changes.

## Test plan
- [x] Verified `DifferentJVMTest` passes on macOS
- [ ] Verify `DifferentJVMTest` passes on Linux (no regression — CI should cover this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)