### PR TITLE
Filter out unsupported JVM arguments from Gradle build environment

### DIFF
--- a/cli/src/main/java/org/jboss/pnc/gradlemanipulator/cli/Main.java
+++ b/cli/src/main/java/org/jboss/pnc/gradlemanipulator/cli/Main.java
@@ -242,7 +242,19 @@ public class Main implements Callable<Void> {
             // Can't use build.addJvmArguments as it wasn't fixed till 8.13
             // https://github.com/gradle/gradle/issues/31462
             // https://github.com/gradle/gradle/issues/25155
-            Collections.addAll(jvmArgs, javaEnvironment.getJvmArguments().toArray(new String[0]));
+
+            // The Gradle build environment may include JVM arguments (e.g. -XX:MaxPermSize,
+            // -XX:+UseConcMarkSweepGC) that were removed in later Java versions. Passing these
+            // to the daemon causes it to fail with "Unrecognized VM option". Filter them based
+            // on the target JDK version.
+            int javaMajorVersion = JavaUtils.getMajorVersion(javaHome);
+            List<String> envJvmArgs = new ArrayList<>(javaEnvironment.getJvmArguments());
+            List<String> filteredArgs = JavaUtils.filterUnsupportedJvmArgs(envJvmArgs, javaMajorVersion);
+            if (filteredArgs.size() != envJvmArgs.size()) {
+                envJvmArgs.removeAll(filteredArgs);
+                logger.warn("Filtering out unsupported JVM arguments: {}", envJvmArgs);
+            }
+            jvmArgs.addAll(filteredArgs);
 
             if (!quiet && colour && StringUtils.isEmpty(System.getenv("NO_COLOR"))) {
                 build.setColorOutput(true);

--- a/common/src/main/java/org/jboss/pnc/gradlemanipulator/common/utils/JavaUtils.java
+++ b/common/src/main/java/org/jboss/pnc/gradlemanipulator/common/utils/JavaUtils.java
@@ -2,6 +2,12 @@ package org.jboss.pnc.gradlemanipulator.common.utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.Getter;
 import lombok.experimental.UtilityClass;
 import org.gradle.internal.jvm.JavaInfo;
@@ -15,6 +21,46 @@ public class JavaUtils {
 
     @Getter
     private static final File javaHome = javaInfo.getJavaHome();
+
+    private static final Pattern JAVA_VERSION_PATTERN = Pattern.compile("JAVA_VERSION=\"(?<major>\\d+).*\"");
+
+    /**
+     * Returns the major Java version for the JDK at the given home directory
+     * by reading its {@code release} file.
+     */
+    public static int getMajorVersion(File jdkHome) throws ManipulationException {
+        Path releaseFile = jdkHome.toPath().resolve("release");
+        try {
+            for (String line : Files.readAllLines(releaseFile)) {
+                Matcher matcher = JAVA_VERSION_PATTERN.matcher(line);
+                if (matcher.matches()) {
+                    return Integer.parseInt(matcher.group("major"));
+                }
+            }
+        } catch (IOException e) {
+            throw new ManipulationException("Unable to read release file from {}", jdkHome, e);
+        }
+        throw new ManipulationException("Unable to determine Java version from {}", jdkHome);
+    }
+
+    /**
+     * Filters out JVM arguments that are unsupported for the given Java major version.
+     *
+     * @return a new list containing only the supported arguments
+     */
+    public static List<String> filterUnsupportedJvmArgs(List<String> args, int javaMajorVersion) {
+        List<String> filtered = new ArrayList<>();
+        for (String arg : args) {
+            if ((arg.startsWith("-XX:MaxPermSize") || arg.startsWith("-XX:PermSize")) && javaMajorVersion >= 9) {
+                continue;
+            }
+            if (arg.equals("-XX:+UseConcMarkSweepGC") && javaMajorVersion >= 14) {
+                continue;
+            }
+            filtered.add(arg);
+        }
+        return filtered;
+    }
 
     public static boolean compareJavaHome(File newHome) throws ManipulationException {
         try {


### PR DESCRIPTION
When a project's gradle.properties includes org.gradle.jvmargs with options removed in later Java versions (e.g. -XX:MaxPermSize, -XX:+UseConcMarkSweepGC), the Gradle daemon fails with "Unrecognized VM option". Detect the target JDK version from its release file and filter out arguments that are no longer supported.

Fixes: https://github.com/project-ncl/gradle-manipulator/issues/571